### PR TITLE
first pass at server-side sockets (+ client comm changes)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,6 +3,9 @@
     <script src="/socket.io/socket.io.js"></script>
     <script>
       const socket = io.connect('http://localhost:3000');
+      socket.on('downloadVars', function(data) {
+        console.log(data);
+      })
     </script>
   </head>
   <body>

--- a/demo/mnist_transfer_learning_model.ts
+++ b/demo/mnist_transfer_learning_model.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs'
+import {Tensor} from '@tensorflow/tfjs';
+import {FederatedModel, ModelDict} from '../src/types';
+
+// https://github.com/tensorflow/tfjs-examples/tree/master/mnist-transfer-cnn
+// tslint:disable-next-line:max-line-length
+const mnistTransferLearningModelURL =
+    'https://storage.googleapis.com/tfjs-models/tfjs/mnist_transfer_cnn_v1/model.json';
+
+export class MnistTransferLearningModel implements FederatedModel {
+  async setup(): Promise<ModelDict> {
+    const model = await tf.loadModel(mnistTransferLearningModelURL);
+
+    for (let i = 0; i < 7; ++i) {
+      model.layers[i].trainable = false;  // freeze conv layers
+    }
+
+    const loss =
+        (inputs: Tensor, labels: Tensor) => {
+          const logits = model.predict(inputs) as Tensor;
+          return tf.losses.softmaxCrossEntropy(logits, labels);
+        }
+
+    return {
+      predict: model.predict, vars: model.trainableWeights, loss: loss
+    }
+  }
+}

--- a/demo/mnist_transfer_learning_model.ts
+++ b/demo/mnist_transfer_learning_model.ts
@@ -15,13 +15,13 @@
  * =============================================================================
  */
 
-import * as tf from '@tensorflow/tfjs'
+import * as tf from '@tensorflow/tfjs';
 import {Scalar, Tensor} from '@tensorflow/tfjs';
 import {FederatedModel, ModelDict} from '../src/index';
 
 // https://github.com/tensorflow/tfjs-examples/tree/master/mnist-transfer-cnn
-// tslint:disable-next-line:max-line-length
 const mnistTransferLearningModelURL =
+    // tslint:disable-next-line:max-line-length
     'https://storage.googleapis.com/tfjs-models/tfjs/mnist_transfer_cnn_v1/model.json';
 
 export class MnistTransferLearningModel implements FederatedModel {
@@ -32,15 +32,12 @@ export class MnistTransferLearningModel implements FederatedModel {
       model.layers[i].trainable = false;  // freeze conv layers
     }
 
-    const loss =
-        (inputs: Tensor, labels: Tensor) => {
-          const logits = model.predict(inputs) as Tensor;
-          const losses = tf.losses.softmaxCrossEntropy(logits, labels);
-          return losses.mean() as Scalar;
-        }
+    const loss = (inputs: Tensor, labels: Tensor) => {
+      const logits = model.predict(inputs) as Tensor;
+      const losses = tf.losses.softmaxCrossEntropy(logits, labels);
+      return losses.mean() as Scalar;
+    };
 
-    return {
-      predict: model.predict, vars: model.trainableWeights, loss: loss
-    }
+    return {predict: model.predict, vars: model.trainableWeights, loss};
   }
 }

--- a/demo/mnist_transfer_learning_model.ts
+++ b/demo/mnist_transfer_learning_model.ts
@@ -16,7 +16,7 @@
  */
 
 import * as tf from '@tensorflow/tfjs'
-import {Tensor} from '@tensorflow/tfjs';
+import {Scalar, Tensor} from '@tensorflow/tfjs';
 import {FederatedModel, ModelDict} from '../src/types';
 
 // https://github.com/tensorflow/tfjs-examples/tree/master/mnist-transfer-cnn
@@ -35,7 +35,7 @@ export class MnistTransferLearningModel implements FederatedModel {
     const loss =
         (inputs: Tensor, labels: Tensor) => {
           const logits = model.predict(inputs) as Tensor;
-          return tf.losses.softmaxCrossEntropy(logits, labels);
+          return tf.losses.softmaxCrossEntropy(logits, labels).mean() as Scalar;
         }
 
     return {

--- a/demo/mnist_transfer_learning_model.ts
+++ b/demo/mnist_transfer_learning_model.ts
@@ -17,7 +17,7 @@
 
 import * as tf from '@tensorflow/tfjs'
 import {Scalar, Tensor} from '@tensorflow/tfjs';
-import {FederatedModel, ModelDict} from '../src/types';
+import {FederatedModel, ModelDict} from '../src/index';
 
 // https://github.com/tensorflow/tfjs-examples/tree/master/mnist-transfer-cnn
 // tslint:disable-next-line:max-line-length
@@ -35,7 +35,8 @@ export class MnistTransferLearningModel implements FederatedModel {
     const loss =
         (inputs: Tensor, labels: Tensor) => {
           const logits = model.predict(inputs) as Tensor;
-          return tf.losses.softmaxCrossEntropy(logits, labels).mean() as Scalar;
+          const losses = tf.losses.softmaxCrossEntropy(logits, labels);
+          return losses.mean() as Scalar;
         }
 
     return {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "node dist/server/server.js",
     "dev": "ts-node src/server/server.ts",
-    "build": "tsc && cp -r demo/ dist/demo/",
+    "build": "tsc && cp -r demo/ dist/",
     "test": "ts-node node_modules/jasmine/bin/jasmine --config=jasmine.json",
     "lint": "tslint -p . -t verbose"
   },
@@ -35,8 +35,8 @@
     "jasmine-core": "~3.1.0",
     "rimraf": "^2.6.2",
     "ts-node": "^6.1.0",
+    "ts-node-dev": "^1.0.0-pre.26",
     "tslint": "~5.8.0",
-    "typescript": "2.7.2",
-    "ts-node-dev": "^1.0.0-pre.26"
+    "typescript": "2.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "start": "node dist/server/server.js",
+    "start": "node dist/src/server/server.js",
     "dev": "ts-node src/server/server.ts",
-    "build": "tsc && cp -r demo/ dist/",
+    "build": "tsc && cp demo/index.html dist/demo/",
     "test": "ts-node node_modules/jasmine/bin/jasmine --config=jasmine.json",
     "lint": "tslint -p . -t verbose"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "@types/express": "^4.16.0",
     "@types/socket.io": "^1.4.34",
     "@types/socket.io-client": "^1.4.32",
+    "es6-promise": "^4.2.4",
     "express": "^4.16.3",
+    "node-fetch": "^2.1.2",
     "socket.io": "^2.1.1"
   },
   "devDependencies": {

--- a/src/client/comm.ts
+++ b/src/client/comm.ts
@@ -24,7 +24,7 @@ import * as socketio from 'socket.io-client';
 
 import {DownloadMsg, Events, UploadMsg} from '../common';
 // tslint:disable-next-line:max-line-length
-import {deserializeVar, SerializedVariable, serializeVar} from '../serialization';
+import {deserializeVar, SerializedVariable, serializeVars} from '../serialization';
 
 const CONNECTION_TIMEOUT = 10 * 1000;
 const UPLOAD_TIMEOUT = 1 * 1000;
@@ -137,16 +137,8 @@ export class VariableSynchroniser {
   protected async serializeCurrentVars(): Promise<UploadMsg> {
     assert(this.numExamples > 0, 'should only serialize if we\'ve seen data');
 
-    const varsP: Array<Promise<SerializedVariable>> = [];
+    const vars = await serializeVars(this.vars);
 
-    this.vars.forEach((value, key) => {
-      if (value instanceof LayerVariable) {
-        varsP.push(serializeVar(tf.variable(value.read())));
-      } else {
-        varsP.push(serializeVar(value));
-      }
-    });
-    const vars = await Promise.all(varsP);
     return {
       numExamples: this.numExamples, /* TODO: ensure this gets updated */
       modelId: this.modelId,

--- a/src/client/comm.ts
+++ b/src/client/comm.ts
@@ -142,7 +142,7 @@ export class VariableSynchroniser {
     return {
       numExamples: this.numExamples, /* TODO: ensure this gets updated */
       modelId: this.modelId,
-      vars: vars
+      vars
     };
   }
 

--- a/src/client/comm.ts
+++ b/src/client/comm.ts
@@ -17,11 +17,12 @@
 
 import * as tf from '@tensorflow/tfjs';
 import {ModelFitConfig, Variable} from '@tensorflow/tfjs';
+import {assert} from '@tensorflow/tfjs-core/dist/util';
 import {Layer} from '@tensorflow/tfjs-layers/dist/engine/topology';
 import {LayerVariable} from '@tensorflow/tfjs-layers/dist/variables';
 import * as socketio from 'socket.io-client';
 
-import {ConnectionMsg, Events, VarsMsg} from '../common';
+import {DownloadMsg, Events, UploadMsg} from '../common';
 // tslint:disable-next-line:max-line-length
 import {deserializeVar, SerializedVariable, serializeVar} from '../serialization';
 
@@ -53,20 +54,19 @@ const UPLOAD_TIMEOUT = 1 * 1000;
  */
 export class VariableSynchroniser {
   public modelId: string;
+  public numExamples: number;
+  public fitConfig: ModelFitConfig;
   private socket: SocketIOClient.Socket;
-  private connMsg: ConnectionMsg;
-  private vars = new Map<string, Variable|LayerVariable>();
-  private acceptUpdate: (msg: VarsMsg) => boolean;
+  private vars: Array<Variable|LayerVariable>;
+  private acceptUpdate: (msg: DownloadMsg) => boolean;
   /**
    * Construct a synchroniser from a list of tf.Variables of tf.LayerVariables.
    * @param {Array<Variable|LayerVariable>} vars - Variables to track and sync
    */
   constructor(
       vars: Array<Variable|LayerVariable>,
-      updateCallback?: (msg: VarsMsg) => boolean) {
-    for (const variable of vars) {
-      this.vars.set(variable.name, variable);
-    }
+      updateCallback?: (msg: DownloadMsg) => boolean) {
+    this.vars = vars;
     if (updateCallback) {
       this.acceptUpdate = updateCallback;
     } else {
@@ -84,10 +84,10 @@ export class VariableSynchroniser {
     return new VariableSynchroniser(tf.util.flatten(layerWeights, []));
   }
 
-  private async connect(url: string): Promise<ConnectionMsg> {
+  private async connect(url: string): Promise<DownloadMsg> {
     this.socket = socketio(url);
-    return fromEvent<ConnectionMsg>(
-        this.socket, Events.Initialise, CONNECTION_TIMEOUT);
+    return fromEvent<DownloadMsg>(
+        this.socket, Events.Download, CONNECTION_TIMEOUT);
   }
 
   /**
@@ -98,18 +98,22 @@ export class VariableSynchroniser {
    * and variables set to their inital values.
    */
   public async initialise(url: string): Promise<ModelFitConfig> {
-    this.connMsg = await this.connect(url);
-    this.setVarsFromMessage(this.connMsg.initVars);
-    this.modelId = this.connMsg.modelId;
+    const connMsg = await this.connect(url);
+    this.setVarsFromMessage(connMsg.vars);
+    this.modelId = connMsg.modelId;
+    this.fitConfig = connMsg.fitConfig;
+    this.numExamples = 0;
 
-    this.socket.on(Events.Download, (msg: VarsMsg) => {
+    this.socket.on(Events.Download, (msg: DownloadMsg) => {
       if (this.acceptUpdate(msg)) {
         this.setVarsFromMessage(msg.vars);
         this.modelId = msg.modelId;
+        this.fitConfig = msg.fitConfig;
+        this.numExamples = 0;
       }
     });
 
-    return this.connMsg.fitConfig;
+    return this.fitConfig;
   }
 
   /**
@@ -117,7 +121,7 @@ export class VariableSynchroniser {
    * @return A promise that resolves when the server has recieved the variables
    */
   public async uploadVars(): Promise<{}> {
-    const msg: VarsMsg = await this.serializeCurrentVars();
+    const msg: UploadMsg = await this.serializeCurrentVars();
     const prom = new Promise((resolve, reject) => {
       const rejectTimer =
           setTimeout(() => reject(`uploadVars timed out`), UPLOAD_TIMEOUT);
@@ -130,7 +134,9 @@ export class VariableSynchroniser {
     return prom;
   }
 
-  protected async serializeCurrentVars(): Promise<VarsMsg> {
+  protected async serializeCurrentVars(): Promise<UploadMsg> {
+    assert(this.numExamples > 0, 'should only serialize if we\'ve seen data');
+
     const varsP: Array<Promise<SerializedVariable>> = [];
 
     this.vars.forEach((value, key) => {
@@ -141,20 +147,21 @@ export class VariableSynchroniser {
       }
     });
     const vars = await Promise.all(varsP);
-    return {clientId: this.connMsg.clientId, modelId: this.modelId, vars};
+    return {
+      numExamples: this.numExamples, /* TODO: ensure this gets updated */
+      modelId: this.modelId,
+      vars: vars
+    };
   }
 
   protected setVarsFromMessage(newVars: SerializedVariable[]) {
-    for (const param of newVars) {
-      if (!this.vars.has(param.name)) {
-        throw new Error(`Recieved message with unexpected param ${
-            param.name}, should be one of ${this.vars.keys()}`);
-      }
-      const varOrLVar = this.vars.get(param.name);
+    for (let i = 0; i < newVars.length; i++) {
+      const newVar = newVars[i];
+      const varOrLVar = this.vars[i];
       if (varOrLVar instanceof LayerVariable) {
-        varOrLVar.write(deserializeVar(param));
+        varOrLVar.write(deserializeVar(newVar));
       } else {
-        varOrLVar.assign(deserializeVar(param));
+        varOrLVar.assign(deserializeVar(newVar));
       }
     }
   }

--- a/src/comm_test.ts
+++ b/src/comm_test.ts
@@ -31,9 +31,7 @@ import {ModelDB} from './server/model_db';
 
 const modelId = '1528400733553';
 const batchSize = 42;
-const FIT_CONFIG = {
-  batchSize: batchSize
-};
+const FIT_CONFIG = {batchSize};
 const PORT = 3000;
 const socketURL = `http://0.0.0.0:${PORT}`;
 const initWeights =
@@ -48,7 +46,9 @@ function waitUntil(done: () => boolean, then: () => void, timeout?: number) {
   };
   const moveOnAnyway = setTimeout(moveOn, timeout || 100);
   const moveOnIfDone = setInterval(() => {
-    if (done()) moveOn();
+    if (done()) {
+      moveOn();
+    }
   }, 1);
 }
 
@@ -59,7 +59,7 @@ describe('Socket API', () => {
   let modelDB: ModelDB;
   let serverAPI: SocketAPI;
   let clientAPI: VariableSynchroniser;
-  let clientVars: Array<Variable>;
+  let clientVars: Variable[];
   let httpServer: http.Server;
 
   beforeEach(async () => {
@@ -125,14 +125,14 @@ describe('Socket API', () => {
     clientAPI.numExamples = 3;
     await clientAPI.uploadVars();
 
-    waitUntil(() => clientAPI.modelId != modelId, () => {
+    waitUntil(() => clientAPI.modelId !== modelId, () => {
       test_util.expectArraysClose(
-          clientVars[0], tf.tensor([1.25, 1.25, 1.25, 1.25], [2, 2]))
+          clientVars[0], tf.tensor([1.25, 1.25, 1.25, 1.25], [2, 2]));
       test_util.expectArraysClose(
-          clientVars[1], tf.tensor([3.25, 2.75, 2.25, 1.75], [1, 4]))
+          clientVars[1], tf.tensor([3.25, 2.75, 2.25, 1.75], [1, 4]));
       expect(clientAPI.numExamples).toBe(0);
       expect(clientAPI.modelId).toBe(modelDB.modelId);
       done();
     });
-  })
+  });
 });

--- a/src/comm_test.ts
+++ b/src/comm_test.ts
@@ -1,0 +1,134 @@
+
+/**
+ * * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+// import * as tf from '@tensorflow/tfjs';
+// import {test_util} from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
+import {test_util, Variable} from '@tensorflow/tfjs';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as path from 'path';
+import * as rimraf from 'rimraf';
+import * as serverSocket from 'socket.io';
+
+import {VariableSynchroniser} from './client/comm';
+import {tensorToJson} from './serialization';
+import {SocketAPI} from './server/comm';
+import {ModelDB} from './server/model_db';
+
+const modelId = '1528400733553';
+const batchSize = 42;
+const FIT_CONFIG = {
+  batchSize: batchSize
+};
+const PORT = 3000;
+const socketURL = `http://0.0.0.0:${PORT}`;
+const initWeights =
+    [tf.tensor([1, 1, 1, 1], [2, 2]), tf.tensor([1, 2, 3, 4], [1, 4])];
+const updateThreshold = 2;
+
+describe('Socket API', () => {
+  let dataDir: string;
+  let modelDir: string;
+  let modelPath: string;
+  let modelDB: ModelDB;
+  let serverAPI: SocketAPI;
+  let clientAPI: VariableSynchroniser;
+  let clientVars: Array<Variable>;
+  let httpServer: http.Server;
+
+  beforeEach(async () => {
+    // Set up model database with our initial weights
+    dataDir = fs.mkdtempSync('/tmp/modeldb_test');
+    modelDir = path.join(dataDir, modelId);
+    modelPath = path.join(dataDir, modelId + '.json');
+    fs.mkdirSync(modelDir);
+    const modelJSON = await Promise.all(initWeights.map(tensorToJson));
+    fs.writeFileSync(modelPath, JSON.stringify({'vars': modelJSON}));
+    modelDB = new ModelDB(dataDir, updateThreshold);
+    await modelDB.setup();
+
+    // Set up the server exposing our upload/download API
+    httpServer = http.createServer();
+    serverAPI = new SocketAPI(modelDB, FIT_CONFIG, serverSocket(httpServer));
+    await serverAPI.setup();
+    await httpServer.listen(PORT);
+
+    // Set up the API client with zeroed out weights
+    clientVars = initWeights.map(t => tf.variable(tf.zerosLike(t)));
+    clientAPI = new VariableSynchroniser(clientVars);
+    await clientAPI.initialise(socketURL);
+  });
+
+  afterEach(async () => {
+    rimraf.sync(dataDir);
+    await httpServer.close();
+  });
+
+  it('transmits fit config on startup', () => {
+    expect(clientAPI.fitConfig.batchSize).toBe(batchSize);
+  });
+
+  it('transmits model version on startup', () => {
+    expect(clientAPI.modelId).toBe(modelId);
+  });
+
+  it('transmits model parameters on startup', () => {
+    test_util.expectArraysClose(clientVars[0], initWeights[0]);
+    test_util.expectArraysClose(clientVars[1], initWeights[1]);
+  });
+
+  it('transmits updates', async () => {
+    let updateFiles = await modelDB.listUpdateFiles();
+    expect(updateFiles.length).toBe(0);
+
+    clientVars[0].assign(tf.tensor([2, 2, 2, 2], [2, 2]));
+    clientAPI.numExamples = 1;
+    await clientAPI.uploadVars();
+
+    updateFiles = await modelDB.listUpdateFiles();
+    expect(updateFiles.length).toBe(1);
+  });
+
+  it('triggers a download after enough uploads', async (done) => {
+    clientVars[0].assign(tf.tensor([2, 2, 2, 2], [2, 2]));
+    clientAPI.numExamples = 1;
+    await clientAPI.uploadVars();
+
+    clientVars[0].assign(tf.tensor([1, 1, 1, 1], [2, 2]));
+    clientVars[1].assign(tf.tensor([4, 3, 2, 1], [1, 4]));
+    clientAPI.numExamples = 3;
+    await clientAPI.uploadVars();
+
+    const timeout = 100;
+    let elapsed = 0;
+    const interval = setInterval(() => {
+      elapsed += 1;
+      if (elapsed > timeout || clientAPI.modelId != modelId) {
+        clearInterval(interval);
+        test_util.expectArraysClose(
+            clientVars[0], tf.tensor([1.25, 1.25, 1.25, 1.25], [2, 2]))
+        test_util.expectArraysClose(
+            clientVars[1], tf.tensor([3.25, 2.75, 2.25, 1.75], [1, 4]))
+        expect(clientAPI.numExamples).toBe(0);
+        expect(clientAPI.modelId).toBe(modelDB.modelId);
+        done();
+      }
+    }, 1);
+  })
+});

--- a/src/common.ts
+++ b/src/common.ts
@@ -42,3 +42,15 @@ export type ConnectionMsg = {
   modelId: string,
   initVars: SerializedVariable[]
 };
+
+export type UploadMsg = {
+  modelId: string,
+  vars: SerializedVariable[],
+  numExamples: number
+};
+
+export type DownloadMsg = {
+  fitConfig: ModelFitConfig,
+  modelId: string,
+  vars: SerializedVariable[]
+};

--- a/src/common.ts
+++ b/src/common.ts
@@ -20,28 +20,9 @@ import {ModelFitConfig} from '@tensorflow/tfjs';
 import {SerializedVariable} from './serialization';
 
 export enum Events {
-  Initialise = 'initialise',
   Download = 'downloadVars',
   Upload = 'uploadVars'
 }
-
-export type TrainingInfo = {
-  nSteps: number
-};
-
-export type VarsMsg = {
-  modelId: string,
-  clientId: string,
-  vars: SerializedVariable[],
-  history?: TrainingInfo
-};
-
-export type ConnectionMsg = {
-  clientId: string,
-  fitConfig: ModelFitConfig,
-  modelId: string,
-  initVars: SerializedVariable[]
-};
 
 export type UploadMsg = {
   modelId: string,
@@ -50,7 +31,7 @@ export type UploadMsg = {
 };
 
 export type DownloadMsg = {
-  fitConfig: ModelFitConfig,
   modelId: string,
   vars: SerializedVariable[]
+  fitConfig: ModelFitConfig,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+export * from './types';

--- a/src/model.ts
+++ b/src/model.ts
@@ -15,7 +15,8 @@
  * =============================================================================
  */
 
+// tslint:disable-next-line:max-line-length
 import {MnistTransferLearningModel} from '../demo/mnist_transfer_learning_model';
 
 // TODO: some kind of flag to determine what model we use
-export default MnistTransferLearningModel;
+export const Model = MnistTransferLearningModel;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs';
+import {Tensor, Variable} from '@tensorflow/tfjs';
+import {LayerVariable} from '@tensorflow/tfjs-layers/dist/variables';
+
+// https://github.com/tensorflow/tfjs-examples/tree/master/mnist-transfer-cnn
+// tslint:disable-next-line:max-line-length
+const mnistTransferLearningModelURL =
+    'https://storage.googleapis.com/tfjs-models/tfjs/mnist_transfer_cnn_v1/model.json';
+
+export type LossFunction = (inputs: Tensor, labels: Tensor) => Tensor;
+export type PredFunction = (inputs: Tensor) => Tensor|Tensor[];
+export type VariableList = Array<Variable|LayerVariable|Tensor>;
+export type ModelDict = {
+  loss: LossFunction,
+  predict: PredFunction,
+  vars: VariableList
+};
+
+export async function setupUserModel(): Promise<ModelDict> {
+  const model = await tf.loadModel(mnistTransferLearningModelURL);
+
+  for (let i = 0; i < 7; ++i) {
+    model.layers[i].trainable = false;  // freeze conv layers
+  }
+
+  const loss =
+      (inputs: Tensor, labels: Tensor) => {
+        const logits = model.predict(inputs) as Tensor;
+        return tf.losses.softmaxCrossEntropy(logits, labels);
+      }
+
+  return {
+    predict: model.predict, vars: model.trainableWeights, loss: loss
+  }
+}

--- a/src/model.ts
+++ b/src/model.ts
@@ -19,4 +19,4 @@
 import {MnistTransferLearningModel} from '../demo/mnist_transfer_learning_model';
 
 // TODO: some kind of flag to determine what model we use
-export const Model = MnistTransferLearningModel;
+export class Model extends MnistTransferLearningModel {}

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -64,9 +64,7 @@ export async function tensorToJson(t: tf.Tensor): Promise<TensorJson> {
     data = await t.data();
   }
   // Note: could make this async / use base64 encoding on the buffer data
-  return {
-    'values': Array.from(data), 'shape': t.shape, 'dtype': t.dtype
-  }
+  return {'values': Array.from(data), 'shape': t.shape, 'dtype': t.dtype};
 }
 
 export function jsonToTensor(j: TensorJson): tf.Tensor {

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -56,12 +56,12 @@ export type TensorJson = {
   dtype?: tf.DataType
 };
 
-export function tensorToJson(t: tf.Tensor): TensorJson {
+export async function tensorToJson(t: tf.Tensor): Promise<TensorJson> {
   let data;
   if (t instanceof LayerVariable) {
-    data = t.read().dataSync();
+    data = await t.read().data();
   } else {
-    data = t.dataSync();
+    data = await t.data();
   }
   // Note: could make this async / use base64 encoding on the buffer data
   return {
@@ -73,8 +73,9 @@ export function jsonToTensor(j: TensorJson): tf.Tensor {
   return tf.tensor(j.values, j.shape, j.dtype || 'float32');
 }
 
-export function serializedToJson(serialized: SerializedVariable): TensorJson {
-  return tensorToJson(deserializeVar(serialized));
+export async function serializedToJson(s: SerializedVariable):
+    Promise<TensorJson> {
+  return tensorToJson(deserializeVar(s));
 }
 
 export async function jsonToSerialized(j: TensorJson):

--- a/src/serialization_test.ts
+++ b/src/serialization_test.ts
@@ -1,0 +1,58 @@
+/**
+ * * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs';
+import {test_util} from '@tensorflow/tfjs-core';
+
+import * as ser from './serialization';
+
+describe('serialization', () => {
+  const floatTensor =
+      tf.tensor3d([[[1.1, 2.2], [3.3, 4.4]], [[5.5, 6.6], [7.7, 8.8]]]);
+  const boolTensor = tf.tensor1d([true, false], 'bool')
+  const intTensor = tf.tensor2d([[1, 2], [3, 4]], [2, 2], 'int32');
+
+  it('converts back and forth to JSON', async () => {
+    const floatJSON = await ser.tensorToJson(floatTensor);
+    const boolJSON = await ser.tensorToJson(boolTensor);
+    const intJSON = await ser.tensorToJson(intTensor);
+    const floatTensor2 = ser.jsonToTensor(floatJSON);
+    const boolTensor2 = ser.jsonToTensor(boolJSON);
+    const intTensor2 = ser.jsonToTensor(intJSON);
+    test_util.expectArraysClose(floatTensor, floatTensor2);
+    test_util.expectArraysClose(boolTensor, boolTensor2);
+    test_util.expectArraysClose(intTensor, intTensor2);
+  });
+
+  it('converts back and forth to SerializedVar', async () => {
+    const floatSerial = await ser.serializeVar(floatTensor);
+    const boolSerial = await ser.serializeVar(boolTensor);
+    const intSerial = await ser.serializeVar(intTensor);
+    const floatTensor2 = ser.deserializeVar(floatSerial);
+    const boolTensor2 = ser.deserializeVar(boolSerial);
+    const intTensor2 = ser.deserializeVar(intSerial);
+    test_util.expectArraysClose(floatTensor, floatTensor2);
+    test_util.expectArraysClose(boolTensor, boolTensor2);
+    test_util.expectArraysClose(intTensor, intTensor2);
+  });
+
+  it('works for an arbitrary chain', async () => {
+    const floatTensor2 = ser.jsonToTensor(await ser.serializedToJson(
+        await ser.jsonToSerialized(await ser.tensorToJson(floatTensor))));
+    test_util.expectArraysClose(floatTensor2, floatTensor);
+  });
+});

--- a/src/serialization_test.ts
+++ b/src/serialization_test.ts
@@ -23,7 +23,7 @@ import * as ser from './serialization';
 describe('serialization', () => {
   const floatTensor =
       tf.tensor3d([[[1.1, 2.2], [3.3, 4.4]], [[5.5, 6.6], [7.7, 8.8]]]);
-  const boolTensor = tf.tensor1d([true, false], 'bool')
+  const boolTensor = tf.tensor1d([true, false], 'bool');
   const intTensor = tf.tensor2d([[1, 2], [3, 4]], [2, 2], 'int32');
 
   it('converts back and forth to JSON', async () => {

--- a/src/server/comm.ts
+++ b/src/server/comm.ts
@@ -66,7 +66,7 @@ export class SocketAPI {
         const updatedVars = await Promise.all(msg.vars.map(serializedToJson));
         const updateJSON = JSON.stringify({
           clientId: socket.client.id,
-          modelId: modelId,
+          modelId,
           numExamples: msg.numExamples,
           vars: updatedVars
         });
@@ -76,15 +76,15 @@ export class SocketAPI {
         ack(true);
 
         // Potentially update the model (asynchronously)
-        if (modelId == this.modelDB.modelId) {
+        if (modelId === this.modelDB.modelId) {
           const updated = await this.modelDB.possiblyUpdate();
           if (updated) {
             // Send new variables to all clients if we updated
             const newVars = await this.downloadMsg();
-            this.io.sockets.emit(Events.Download, newVars)
+            this.io.sockets.emit(Events.Download, newVars);
           }
         }
-      })
+      });
     });
   }
 }

--- a/src/server/comm.ts
+++ b/src/server/comm.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {ModelFitConfig} from '@tensorflow/tfjs';
+import * as fs from 'fs';
+import * as path from 'path';
+import {Server, Socket} from 'socket.io';
+import {promisify} from 'util';
+import * as uuid from 'uuid/v4';
+
+import {DownloadMsg, Events, UploadMsg} from '../common';
+import {serializedToJson, serializeVar} from '../serialization';
+
+import {ModelDB} from './model_db';
+
+const writeFile = promisify(fs.writeFile);
+
+export class SocketAPI {
+  modelDB: ModelDB;
+  fitConfig: ModelFitConfig;
+  io: Server;
+
+  constructor(modelDB: ModelDB, fitConfig: ModelFitConfig, io: Server) {
+    this.modelDB = modelDB;
+    this.fitConfig = fitConfig;
+    this.io = io;
+  }
+
+  async downloadMsg(): Promise<DownloadMsg> {
+    const varsJson = await this.modelDB.currentVars();
+    const varsSeri = await Promise.all(varsJson.map(serializeVar));
+    return {
+      fitConfig: this.fitConfig,
+      modelId: this.modelDB.modelId,
+      vars: varsSeri
+    };
+  }
+
+  async setup() {
+    this.io.on('connection', async (socket: Socket) => {
+      // Send current variables to newly connected client
+      const initVars = await this.downloadMsg();
+      socket.emit(Events.Download, initVars);
+
+      // When a client sends us updated weights
+      socket.on(Events.Upload, async (msg: UploadMsg, ack) => {
+        // Save them to a file
+        const modelId = msg.modelId;
+        const updateId = uuid();
+        const updatePath =
+            path.join(this.modelDB.dataDir, modelId, updateId + '.json');
+        const updatedVars = await Promise.all(msg.vars.map(serializedToJson));
+        const updateJSON = JSON.stringify({
+          clientId: socket.client.id,
+          modelId: modelId,
+          numExamples: msg.numExamples,
+          vars: updatedVars
+        });
+        await writeFile(updatePath, updateJSON);
+
+        // Let them know we're done saving
+        ack(true);
+
+        // Potentially update the model (asynchronously)
+        if (modelId == this.modelDB.modelId) {
+          const updated = await this.modelDB.possiblyUpdate();
+          if (updated) {
+            // Send new variables to all clients if we updated
+            const newVars = await this.downloadMsg();
+            this.io.sockets.emit(Events.Download, newVars)
+          }
+        }
+      })
+    });
+  }
+}

--- a/src/server/fetch_polyfill.ts
+++ b/src/server/fetch_polyfill.ts
@@ -1,0 +1,13 @@
+import * as es6Promise from 'es6-promise';
+es6Promise.polyfill();
+
+eval(`
+var realFetch = require('node-fetch');
+
+if (!global.fetch) {
+	global.fetch = realFetch;
+	global.Response = realFetch.Response;
+	global.Headers = realFetch.Headers;
+	global.Request = realFetch.Request;
+}
+`);

--- a/src/server/fetch_polyfill.ts
+++ b/src/server/fetch_polyfill.ts
@@ -1,3 +1,20 @@
+/**
+ * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
 import * as es6Promise from 'es6-promise';
 es6Promise.polyfill();
 
@@ -5,9 +22,9 @@ eval(`
 var realFetch = require('node-fetch');
 
 if (!global.fetch) {
-	global.fetch = realFetch;
-	global.Response = realFetch.Response;
-	global.Headers = realFetch.Headers;
-	global.Request = realFetch.Request;
+  global.fetch = realFetch;
+  global.Response = realFetch.Response;
+  global.Headers = realFetch.Headers;
+  global.Request = realFetch.Request;
 }
 `);

--- a/src/server/model_db.ts
+++ b/src/server/model_db.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {promisify} from 'util';
 
-import Model from '../model';
+import {Model} from '../model';
 import {jsonToTensor, TensorJson, tensorToJson} from '../serialization';
 
 const DEFAULT_MIN_UPDATES = 10;

--- a/src/server/model_db.ts
+++ b/src/server/model_db.ts
@@ -134,7 +134,8 @@ export class ModelDB {
     const newModelId = generateNewId();
     const newModelDir = path.join(this.dataDir, newModelId);
     const newModelPath = path.join(this.dataDir, newModelId + '.json');
-    const newModelJSON = JSON.stringify({'vars': newVars.map(tensorToJson)});
+    const newVarsJSON = await Promise.all(newVars.map(tensorToJson));
+    const newModelJSON = JSON.stringify({'vars': newVarsJSON});
     await writeFile(newModelPath, newModelJSON);
     await mkdir(newModelDir);
     this.modelId = newModelId;

--- a/src/server/model_db.ts
+++ b/src/server/model_db.ts
@@ -105,7 +105,8 @@ export class ModelDB {
   }
 
   async update() {
-    const updatedVars = await this.currentVars();
+    const currentVars = await this.currentVars();
+    const updatedVars = currentVars.map(v => tf.zerosLike(v));
     const updateFiles = await this.listUpdateFiles();
     const updatesJSON = await Promise.all(updateFiles.map(readJSON));
 

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -117,4 +117,4 @@ describe('ModelDB', () => {
     const newUpdateFiles = await db.listUpdateFiles();
     expect(newUpdateFiles.length).toBe(0);
   });
-})
+});

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-// tslint:disable-next-line:max-line-length
 import {test_util} from '@tensorflow/tfjs-core';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -91,7 +91,7 @@ describe('ModelDB', () => {
     expect(db.modelId).not.toBe(modelId);
     const newVars = await db.currentVars();
     test_util.expectArraysClose(newVars[0], [0.4, -0.4, 0.6, -0.6]);
-    test_util.expectArraysClose(newVars[1], [1.2, 2.8, 3.2, 4.8]);
+    test_util.expectArraysClose(newVars[1], [0.2, 0.8, 0.2, 0.8]);
   });
 
   it('only performs update after passing a threshold', async () => {

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -94,7 +94,8 @@ describe('ModelDB', () => {
 
   it('only performs update after passing a threshold', async () => {
     const db = new ModelDB(dataDir, 3);
-    await db.possiblyUpdate();
+    let updated = await db.possiblyUpdate();
+    expect(updated).toBe(false);
     expect(db.modelId).toBe(modelId);
     const oldUpdateFiles = await db.listUpdateFiles();
     expect(oldUpdateFiles.length).toBe(2);
@@ -107,7 +108,8 @@ describe('ModelDB', () => {
         {values: [0, 0, 0, 0], shape: [1, 4]}
       ]
     }));
-    await db.possiblyUpdate();
+    updated = await db.possiblyUpdate();
+    expect(updated).toBe(true);
     expect(db.modelId).not.toBe(modelId);
     const newUpdateFiles = await db.listUpdateFiles();
     expect(newUpdateFiles.length).toBe(0);

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -67,13 +67,15 @@ describe('ModelDB', () => {
     rimraf.sync(dataDir);
   });
 
-  it('defaults to treating the latest model as current', () => {
+  it('defaults to treating the latest model as current', async () => {
     const db = new ModelDB(dataDir);
+    await db.setup();
     expect(db.modelId).toBe(modelId);
   });
 
   it('loads variables from JSON', async () => {
     const db = new ModelDB(dataDir);
+    await db.setup();
     const vars = await db.currentVars();
     test_util.expectArraysClose(vars[0], [0, 0, 0, 0]);
     test_util.expectArraysClose(vars[1], [1, 2, 3, 4]);
@@ -85,6 +87,7 @@ describe('ModelDB', () => {
 
   it('updates the model using a weighted average', async () => {
     const db = new ModelDB(dataDir);
+    await db.setup();
     await db.update();
     expect(db.modelId).not.toBe(modelId);
     const newVars = await db.currentVars();
@@ -94,6 +97,7 @@ describe('ModelDB', () => {
 
   it('only performs update after passing a threshold', async () => {
     const db = new ModelDB(dataDir, 3);
+    await db.setup();
     let updated = await db.possiblyUpdate();
     expect(updated).toBe(false);
     expect(db.modelId).toBe(modelId);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -66,11 +66,12 @@ io.on('connection', async (socket: socketIO.Socket) => {
     const modelId = msg.modelId;
     const updateId = uuid();
     const updatePath = path.join(dataDir, modelId, updateId + '.json');
+    const updatedVars = await Promise.all(msg.vars.map(serializedToJson));
     const updateJSON = JSON.stringify({
       clientId: socket.client.id,
       modelId: modelId,
       numExamples: msg.numExamples,
-      vars: msg.vars.map(serializedToJson)
+      vars: updatedVars
     });
     await writeFile(updatePath, updateJSON);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -41,8 +41,8 @@ const app = express();
 const server = http.createServer(app);
 const io = socketIO(server);
 const writeFile = promisify(fs.writeFile);
-const indexPath = path.resolve(__dirname + '/../demo/index.html');
-const dataDir = path.resolve(__dirname + '/../data');
+const indexPath = path.resolve(__dirname + '/../../demo/index.html');
+const dataDir = path.resolve(__dirname + '/../../data');
 const modelDB = new ModelDB(dataDir);
 
 async function downloadMsg(): Promise<DownloadMsg> {
@@ -89,6 +89,8 @@ io.on('connection', async (socket: socketIO.Socket) => {
   })
 });
 
-server.listen(3000, () => {
-  console.log('listening on 3000');
+modelDB.setup().then(() => {
+  server.listen(3000, () => {
+    console.log('listening on 3000');
+  });
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,77 +21,32 @@ import './fetch_polyfill';
 
 import * as express from 'express';
 import {Request, Response} from 'express';
-import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import * as socketIO from 'socket.io';
-import {promisify} from 'util';
-import * as uuid from 'uuid/v4';
 
-import {DownloadMsg, Events, UploadMsg} from '../common';
-import {serializedToJson, serializeVar} from '../serialization';
-
+import {SocketAPI} from './comm';
 import {ModelDB} from './model_db';
-
-const FIT_CONFIG = {
-  batchSize: 10
-};
 
 const app = express();
 const server = http.createServer(app);
 const io = socketIO(server);
-const writeFile = promisify(fs.writeFile);
 const indexPath = path.resolve(__dirname + '/../../demo/index.html');
 const dataDir = path.resolve(__dirname + '/../../data');
 const modelDB = new ModelDB(dataDir);
-
-async function downloadMsg(): Promise<DownloadMsg> {
-  const varsJson = await modelDB.currentVars();
-  const varsSeri = await Promise.all(varsJson.map(serializeVar));
-  return {fitConfig: FIT_CONFIG, modelId: modelDB.modelId, vars: varsSeri};
-}
+const FIT_CONFIG = {
+  batchSize: 10
+};
+const socketAPI = new SocketAPI(modelDB, FIT_CONFIG, io);
 
 app.get('/', (req: Request, res: Response) => {
   res.sendFile(indexPath);
 });
 
-io.on('connection', async (socket: socketIO.Socket) => {
-  // Send current variables to newly connected client
-  const initVars = await downloadMsg();
-  socket.emit(Events.Download, initVars);
-
-  // When a client sends us updated weights
-  socket.on(Events.Upload, async (msg: UploadMsg, ack) => {
-    // Save them to a file
-    const modelId = msg.modelId;
-    const updateId = uuid();
-    const updatePath = path.join(dataDir, modelId, updateId + '.json');
-    const updatedVars = await Promise.all(msg.vars.map(serializedToJson));
-    const updateJSON = JSON.stringify({
-      clientId: socket.client.id,
-      modelId: modelId,
-      numExamples: msg.numExamples,
-      vars: updatedVars
-    });
-    await writeFile(updatePath, updateJSON);
-
-    // Let them know we're done saving
-    ack(true);
-
-    // Potentially update the model (asynchronously)
-    if (modelId == modelDB.modelId) {
-      const updated = await modelDB.possiblyUpdate();
-      if (updated) {
-        // Send new variables to all clients if we updated
-        const newVars = downloadMsg();
-        io.sockets.emit(Events.Download, newVars)
-      }
-    }
-  })
-});
-
 modelDB.setup().then(() => {
-  server.listen(3000, () => {
-    console.log('listening on 3000');
+  socketAPI.setup().then(() => {
+    server.listen(3000, () => {
+      console.log('listening on 3000');
+    });
   });
 });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -19,20 +19,73 @@
 
 import * as express from 'express';
 import {Request, Response} from 'express';
+import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
 import * as socketIO from 'socket.io';
+import {promisify} from 'util';
+import * as uuid from 'uuid/v4';
+
+import {DownloadMsg, Events, UploadMsg} from '../common';
+import {serializedToJson, serializeVar} from '../serialization';
+
+import {ModelDB} from './model_db';
+
+const FIT_CONFIG = {
+  batchSize: 10
+};
 
 const app = express();
 const server = http.createServer(app);
 const io = socketIO(server);
+const writeFile = promisify(fs.writeFile);
+
+const dataDir = path.resolve(__dirname + '/../data');
+const indexPath = path.resolve(__dirname + '/../demo/index.html');
+const modelDB = new ModelDB(dataDir);
 
 app.get('/', (req: Request, res: Response) => {
-  res.sendFile(path.resolve(__dirname + '/../demo/index.html'));
+  res.sendFile(indexPath);
 });
 
-io.on('connection', (socket: socketIO.Socket) => {
-  console.log('a user connected');
+async function downloadMsg(): Promise<DownloadMsg> {
+  const varsJson = await modelDB.currentVars();
+  const varsSeri = await Promise.all(varsJson.map(serializeVar));
+  return {fitConfig: FIT_CONFIG, modelId: modelDB.modelId, vars: varsSeri};
+}
+
+io.on('connection', async (socket: socketIO.Socket) => {
+  // Send current variables to newly connected client
+  const initVars = await downloadMsg();
+  socket.emit(Events.Download, initVars);
+
+  // When a client sends us updated weights
+  socket.on(Events.Upload, async (msg: UploadMsg, ack) => {
+    // Save them to a file
+    const modelId = msg.modelId;
+    const updateId = uuid();
+    const updatePath = path.join(dataDir, modelId, updateId + '.json');
+    const updateJSON = JSON.stringify({
+      clientId: socket.client.id,
+      modelId: modelId,
+      numExamples: msg.numExamples,
+      vars: msg.vars.map(serializedToJson)
+    });
+    await writeFile(updatePath, updateJSON);
+
+    // Let them know we're done saving
+    ack(true);
+
+    // Potentially update the model (asynchronously)
+    if (modelId == modelDB.modelId) {
+      const updated = await modelDB.possiblyUpdate();
+      if (updated) {
+        // Send new variables to all clients if we updated
+        const newVars = downloadMsg();
+        io.sockets.emit(Events.Download, newVars)
+      }
+    }
+  })
 });
 
 server.listen(3000, () => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,6 +17,8 @@
 
 /** Server code */
 
+import './fetch_polyfill';
+
 import * as express from 'express';
 import {Request, Response} from 'express';
 import * as fs from 'fs';
@@ -39,20 +41,19 @@ const app = express();
 const server = http.createServer(app);
 const io = socketIO(server);
 const writeFile = promisify(fs.writeFile);
-
-const dataDir = path.resolve(__dirname + '/../data');
 const indexPath = path.resolve(__dirname + '/../demo/index.html');
+const dataDir = path.resolve(__dirname + '/../data');
 const modelDB = new ModelDB(dataDir);
-
-app.get('/', (req: Request, res: Response) => {
-  res.sendFile(indexPath);
-});
 
 async function downloadMsg(): Promise<DownloadMsg> {
   const varsJson = await modelDB.currentVars();
   const varsSeri = await Promise.all(varsJson.map(serializeVar));
   return {fitConfig: FIT_CONFIG, modelId: modelDB.modelId, vars: varsSeri};
 }
+
+app.get('/', (req: Request, res: Response) => {
+  res.sendFile(indexPath);
+});
 
 io.on('connection', async (socket: socketIO.Socket) => {
   // Send current variables to newly connected client

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,10 +15,10 @@
  * =============================================================================
  */
 
-import {Tensor, Variable} from '@tensorflow/tfjs';
+import {Scalar, Tensor, Variable} from '@tensorflow/tfjs';
 import {LayerVariable} from '@tensorflow/tfjs-layers/dist/variables';
 
-export type LossFun = (inputs: Tensor, labels: Tensor) => Tensor;
+export type LossFun = (inputs: Tensor, labels: Tensor) => Scalar;
 export type PredFun = (inputs: Tensor) => Tensor|Tensor[];
 export type VarList = Array<Variable|LayerVariable>;
 export type ModelDict = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,18 @@
  * =============================================================================
  */
 
-import {MnistTransferLearningModel} from '../demo/mnist_transfer_learning_model';
+import {Tensor, Variable} from '@tensorflow/tfjs';
+import {LayerVariable} from '@tensorflow/tfjs-layers/dist/variables';
 
-// TODO: some kind of flag to determine what model we use
-export default MnistTransferLearningModel;
+export type LossFun = (inputs: Tensor, labels: Tensor) => Tensor;
+export type PredFun = (inputs: Tensor) => Tensor|Tensor[];
+export type VarList = Array<Variable|LayerVariable>;
+export type ModelDict = {
+  vars: VarList,
+  loss: LossFun,
+  predict: PredFun
+};
+
+export interface FederatedModel {
+  setup(): Promise<ModelDict>;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     "experimentalDecorators": true
   },
   "include": [
-    "src/"
+    "src/",
+    "demo/"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,6 +518,10 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es6-promise@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -949,6 +953,10 @@ node-emoji@^1.4.1:
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
   dependencies:
     lodash.toarray "^4.4.0"
+
+node-fetch@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
 node-notifier@^4.0.2:
   version "4.6.1"


### PR DESCRIPTION
This implements a server websocket API that supports two basic message types: sending a `DownloadMsg` and receiving an `UploadMsg`.

The serialization/deserialization logic is in flux and will definitely be streamlined, but this should work as a first pass. The main TODO is to get this working with the client at the API level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/federated-learning/5)
<!-- Reviewable:end -->
