### PR TITLE
Use LevelDB instead of manual filesystem for model database

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,13 @@
     "@types/express": "^4.16.0",
     "@types/socket.io": "^1.4.34",
     "@types/socket.io-client": "^1.4.32",
+    "encoding-down": "^5.0.3",
     "es6-promise": "^4.2.4",
     "express": "^4.16.3",
+    "level": "^4.0.0",
+    "level-typings": "git+https://github.com/Level/typings.git",
+    "leveldown": "^4.0.1",
+    "levelup": "^3.0.1",
     "node-fetch": "^2.1.2",
     "socket.io": "^2.1.1"
   },

--- a/src/abstract-leveldown.ts
+++ b/src/abstract-leveldown.ts
@@ -1,0 +1,108 @@
+/* tslint:disable */
+declare module 'abstract-leveldown' {
+  type ObjectAny = { [index: string]: any; };
+  type ErrorCallback = (err: Error|undefined) => void;
+  type ErrorValueCallback<V> = (err: Error|undefined, value: V) => void;
+  type ErrorKeyValueCallback<K, V> = (err: Error|undefined, key: K, value: V) =>
+      void;
+
+  export interface AbstractOpenOptions extends ObjectAny {
+    createIfMissing?: boolean;
+    errorIfExists?: boolean;
+  }
+
+  export interface AbstractGetOptions extends ObjectAny {
+    asBuffer?: boolean;
+  }
+
+  export interface AbstractPutOptions extends ObjectAny {}
+
+  export interface AbstractDelOptions extends ObjectAny {}
+
+  export interface AbstractBatchOptions extends ObjectAny {}
+
+  export interface AbstractLevelDOWN<K = any, V = any> extends ObjectAny {
+    open(cb: ErrorCallback): void;
+    open(options: AbstractOpenOptions, cb: ErrorCallback): void;
+
+    close(cb: ErrorCallback): void;
+
+    get(key: K, cb: ErrorValueCallback<V>): void;
+    get(key: K, options: AbstractGetOptions, cb: ErrorValueCallback<V>): void;
+
+    put(key: K, value: V, cb: ErrorCallback): void;
+    put(key: K, value: V, options: AbstractPutOptions, cb: ErrorCallback): void;
+
+    del(key: K, cb: ErrorCallback): void;
+    del(key: K, options: AbstractDelOptions, cb: ErrorCallback): void;
+
+    batch(): AbstractChainedBatch;
+    batch(array: AbstractBatch[], cb: ErrorCallback): AbstractChainedBatch;
+    batch(
+        array: AbstractBatch[], options: AbstractBatchOptions,
+        cb: ErrorCallback): AbstractChainedBatch;
+
+    iterator(options?: AbstractIteratorOptions): AbstractIterator;
+    (..._: any[]): any;
+  }
+
+  interface AbstractLevelDOWNConstructor {
+    new<K = any, V = any>(location: string): AbstractLevelDOWN<K, V>;
+    <K = any, V = any>(location: string): AbstractLevelDOWN<K, V>;
+  }
+
+  export interface AbstractIteratorOptions<K = any> extends ObjectAny {
+    gt?: K;
+    gte?: K;
+    lt?: K;
+    lte?: K;
+    reverse?: boolean;
+    limit?: number;
+    keys?: boolean;
+    values?: boolean;
+    keyAsBuffer?: boolean;
+    valueAsBuffer?: boolean;
+  }
+
+  export type AbstractBatch<K = any, V = any> = PutBatch<K, V>|DelBatch<K>
+
+      export interface PutBatch<K = any, V = any> {
+    type: 'put', key: K, value: V
+  }
+
+  export interface DelBatch<K = any, V = any> {
+    type: 'del', key: K
+  }
+
+  export interface AbstractChainedBatch<K = any, V = any> extends
+      AbstractChainedBatchConstructor, ObjectAny {
+    put(key: K, value: V): this;
+    del(key: K): this;
+    clear(): this;
+    write(cb: ErrorCallback): any
+    write(options: any, cb: ErrorCallback): any
+  }
+
+  interface AbstractChainedBatchConstructor {
+    new(db: any): AbstractChainedBatch;
+    (db: any): AbstractChainedBatch;
+  }
+
+  export interface AbstractIterator<K = any, V = any> extends
+      AbstractChainedBatchConstructor {
+    db: AbstractLevelDOWN;
+    next(cb: ErrorKeyValueCallback<K, V>): this;
+    end(cb: ErrorCallback): void;
+  }
+
+  interface AbstractIteratorConstructor {
+    new(db: any): AbstractIterator;
+    (db: any): AbstractIterator;
+  }
+
+  export const AbstractLevelDOWN: AbstractLevelDOWNConstructor
+  export const AbstractIterator: AbstractIteratorConstructor
+  export const AbstractChainedBatch: AbstractChainedBatchConstructor
+
+  // export default AbstractLevelDOWN;
+}

--- a/src/comm_test.ts
+++ b/src/comm_test.ts
@@ -18,9 +18,11 @@
 
 import * as tf from '@tensorflow/tfjs';
 import {test_util, Variable} from '@tensorflow/tfjs';
+import EncodingDown from 'encoding-down';
 import * as fs from 'fs';
 import * as http from 'http';
-import * as path from 'path';
+import LevelDown from 'leveldown';
+import LevelUp from 'levelup';
 import * as rimraf from 'rimraf';
 import * as serverSocket from 'socket.io';
 
@@ -50,8 +52,6 @@ function waitUntil(done: () => boolean, then: () => void, timeout?: number) {
 
 describe('Socket API', () => {
   let dataDir: string;
-  let modelDir: string;
-  let modelPath: string;
   let modelDB: ModelDB;
   let serverAPI: SocketAPI;
   let clientAPI: VariableSynchroniser;
@@ -61,11 +61,13 @@ describe('Socket API', () => {
   beforeEach(async () => {
     // Set up model database with our initial weights
     dataDir = fs.mkdtempSync('/tmp/modeldb_test');
-    modelDir = path.join(dataDir, modelId);
-    modelPath = path.join(dataDir, modelId + '.json');
-    fs.mkdirSync(modelDir);
-    const modelJSON = await Promise.all(initWeights.map(tensorToJson));
-    fs.writeFileSync(modelPath, JSON.stringify({'vars': modelJSON}));
+    const lvl =
+        LevelUp(EncodingDown(LevelDown(dataDir), {valueEncoding: 'json'}));
+    const modelVars = await Promise.all(initWeights.map(tensorToJson));
+    await lvl.put('currentModelId', modelId);
+    await lvl.put(modelId, {'vars': modelVars});
+    await lvl.close();
+
     modelDB = new ModelDB(dataDir, updateThreshold);
     await modelDB.setup();
 
@@ -100,15 +102,15 @@ describe('Socket API', () => {
   });
 
   it('transmits updates', async () => {
-    let updateFiles = await modelDB.listUpdateFiles();
-    expect(updateFiles.length).toBe(0);
+    let numUpdates = await modelDB.countUpdates();
+    expect(numUpdates).toBe(0);
 
     clientVars[0].assign(tf.tensor([2, 2, 2, 2], [2, 2]));
     clientAPI.numExamples = 1;
     await clientAPI.uploadVars();
 
-    updateFiles = await modelDB.listUpdateFiles();
-    expect(updateFiles.length).toBe(1);
+    numUpdates = await modelDB.countUpdates();
+    expect(numUpdates).toBe(1);
   });
 
   it('triggers a download after enough uploads', async (done) => {

--- a/src/comm_test.ts
+++ b/src/comm_test.ts
@@ -44,12 +44,8 @@ function waitUntil(done: () => boolean, then: () => void, timeout?: number) {
     clearTimeout(moveOnAnyway);
     then();
   };
+  const moveOnIfDone = setInterval(() => done() && moveOn(), 1);
   const moveOnAnyway = setTimeout(moveOn, timeout || 100);
-  const moveOnIfDone = setInterval(() => {
-    if (done()) {
-      moveOn();
-    }
-  }, 1);
 }
 
 describe('Socket API', () => {

--- a/src/encoding-down.ts
+++ b/src/encoding-down.ts
@@ -1,0 +1,52 @@
+/* tslint:disable */
+declare module 'encoding-down' {
+import {AbstractLevelDOWN, AbstractIteratorOptions, AbstractIterator, AbstractOpenOptions, AbstractPutOptions, AbstractGetOptions, AbstractDelOptions, AbstractBatchOptions, ErrorCallback, ErrorValueCallback, AbstractChainedBatch, AbstractBatch, ObjectAny} from 'abstract-leveldown';
+
+import {CodecOptions, CodecEncoder} from 'level-codec';
+
+  export interface EncodingDown<K = any, V = any> extends
+      AbstractLevelDOWN<K, V> {
+    get(key: K, cb: ErrorValueCallback<V>): void;
+    get(key: K, options: EncodingDownGetOptions,
+        cb: ErrorValueCallback<V>): void;
+
+    put(key: K, value: V, cb: ErrorCallback): void;
+    put(key: K, value: V, options: EncodingDownPutOptions,
+        cb: ErrorCallback): void;
+
+    del(key: K, cb: ErrorCallback): void;
+    del(key: K, options: EncodingDownDelOptions, cb: ErrorCallback): void;
+
+    batch(): EncodingDownChainedBatch;
+    batch(array: AbstractBatch[], cb: ErrorCallback): EncodingDownChainedBatch;
+    batch(
+        array: AbstractBatch[], options: EncodingDownBatchOptions,
+        cb: ErrorCallback): EncodingDownChainedBatch;
+
+    iterator(options?: EncodingDownIteratorOptions): AbstractIterator;
+  }
+
+  export interface EncodingDownGetOptions extends AbstractGetOptions,
+                                                  CodecOptions {}
+  export interface EncodingDownPutOptions extends AbstractPutOptions,
+                                                  CodecOptions {}
+  export interface EncodingDownDelOptions extends AbstractDelOptions,
+                                                  CodecOptions {}
+  export interface EncodingDownBatchOptions extends AbstractBatchOptions,
+                                                    CodecOptions {}
+  export interface EncodingDownIteratorOptions extends AbstractIteratorOptions,
+                                                       CodecOptions {}
+
+  export interface EncodingDownChainedBatch<K = any, V = any> extends
+      AbstractChainedBatch<K, V>{write(cb: any): any
+    write(options: CodecOptions & ObjectAny, cb: any): any
+  }
+
+  interface EncodingDOWNConstructor {
+      (db: AbstractLevelDOWN, options?: CodecOptions): EncodingDown
+          new(db: AbstractLevelDOWN, options?: CodecOptions): EncodingDown
+    }
+
+    const EncodingDOWN: EncodingDOWNConstructor;
+    export default EncodingDOWN;
+}

--- a/src/leveldown.ts
+++ b/src/leveldown.ts
@@ -1,0 +1,84 @@
+/* tslint:disable */
+declare module 'leveldown' {
+import {AbstractLevelDOWN, AbstractIteratorOptions, AbstractIterator, AbstractOpenOptions, AbstractPutOptions, AbstractGetOptions, AbstractDelOptions, AbstractBatchOptions, ErrorCallback, ErrorValueCallback, AbstractChainedBatch, AbstractBatch} from 'abstract-leveldown';
+
+  export type Bytes = string|Buffer;
+  export type ErrorSizeCallback = (err: Error|undefined, size: number) => void;
+
+  export interface LevelDown extends AbstractLevelDOWN<Bytes, Bytes> {
+    open(cb: ErrorCallback): void;
+    open(options: LevelDownOpenOptions, cb: ErrorCallback): void;
+
+    get(key: Bytes, cb: ErrorValueCallback<Bytes>): void;
+    get(key: Bytes, options: LevelDownGetOptions,
+        cb: ErrorValueCallback<Bytes>): void;
+
+    put(key: Bytes, value: Bytes, cb: ErrorCallback): void;
+    put(key: Bytes, value: Bytes, options: LevelDownPutOptions,
+        cb: ErrorCallback): void;
+
+    del(key: Bytes, cb: ErrorCallback): void;
+    del(key: Bytes, options: LevelDownDelOptions, cb: ErrorCallback): void;
+
+    batch(): AbstractChainedBatch<Bytes, Bytes>;
+    batch(array: AbstractBatch[], cb: ErrorCallback):
+        AbstractChainedBatch<Bytes, Bytes>;
+    batch(
+        array: AbstractBatch[], options: LevelDownBatchOptions,
+        cb: ErrorCallback): AbstractChainedBatch<Bytes, Bytes>;
+
+    approximateSize(start: Bytes, end: Bytes, cb: ErrorSizeCallback): void;
+    compactRange(start: Bytes, end: Bytes, cb: ErrorCallback): void;
+    getProperty(property: string): string;
+    destroy(location: string, cb: ErrorCallback): void;
+    repair(location: string, cb: ErrorCallback): void;
+    iterator(options?: LevelDownIteratorOptions): LevelDownIterator
+  }
+
+  interface LevelDownConstructor {
+    new(location: string): LevelDown;
+    (location: string): LevelDown;
+  }
+
+  export interface LevelDownOpenOptions extends AbstractOpenOptions {
+    compression?: boolean;
+    cacheSize?: number;
+    writeBufferSize?: number;
+    blockSize?: number;
+    maxOpenFiles?: number;
+    blockRestartInterval?: number;
+    maxFileSize?: number;
+  }
+
+  export interface LevelDownGetOptions extends AbstractGetOptions {
+    fillCache?: boolean;
+  }
+
+  export interface LevelDownPutOptions extends AbstractPutOptions {
+    sync?: boolean
+  }
+
+  export interface LevelDownDelOptions extends AbstractDelOptions {
+    sync?: boolean;
+  }
+
+  export interface LevelDownBatchOptions extends AbstractBatchOptions {
+    sync?: boolean;
+  }
+
+  export interface LevelDownIteratorOptions extends
+      AbstractIteratorOptions<Bytes> {
+    fillCache?: boolean;
+  }
+
+  export interface LevelDownIterator extends AbstractIterator<Bytes, Bytes> {
+    seek(key: Bytes): void;
+    binding: any;
+    cache: any;
+    finished: any;
+    fastFuture: any;
+  }
+
+  const LevelDOWN: LevelDownConstructor;
+  export default LevelDOWN;
+}

--- a/src/levelup.ts
+++ b/src/levelup.ts
@@ -1,0 +1,119 @@
+/* tslint:disable */
+declare module 'levelup' {
+import {EventEmitter} from 'events';
+import * as levelerrors from 'level-errors';
+import {AbstractLevelDOWN, AbstractIteratorOptions, AbstractBatch, ErrorCallback, AbstractPutOptions, ErrorValueCallback, AbstractGetOptions, AbstractDelOptions} from 'abstract-leveldown';
+
+  type LevelUpPut<K, V, O> =
+      ((key: K, value: V, callback: ErrorCallback) => void)&
+      ((key: K, value: V, options: O, callback: ErrorCallback) => void)&
+      ((key: K, value: V, options?: O) => Promise<void>);
+
+  type LevelUpGet<K, V, O> =
+      ((key: K, callback: ErrorValueCallback<V>) => void)&
+      ((key: K, options: O, callback: ErrorValueCallback<V>) => void)&
+      ((key: K, options?: O) => Promise<V>);
+
+  type LevelUpDel<K, O> = ((key: K, callback: ErrorCallback) => void)&
+      ((key: K, options: O, callback: ErrorCallback) => void)&
+      ((key: K, options?: O) => Promise<void>);
+
+  type LevelUpBatch<K, O> = ((key: K, callback: ErrorCallback) => void)&
+      ((key: K, options: O, callback: ErrorCallback) => void)&
+      ((key: K, options?: O) => Promise<void>);
+
+  type InferDBPut<DB> = DB extends {
+    put: (key: infer K, value: infer V, options: infer O, cb: any) => void
+  } ?
+      LevelUpPut<K, V, O>:
+      LevelUpPut<any, any, AbstractPutOptions>;
+
+  type InferDBGet<DB> = DB extends {
+    get:
+        (key: infer K, options: infer O,
+         callback: ErrorValueCallback<infer V>) => void
+  } ?
+      LevelUpGet<K, V, O>:
+      LevelUpGet<any, any, AbstractGetOptions>;
+
+  type InferDBDel<DB> = DB extends {
+    del: (key: infer K, options: infer O, callback: ErrorCallback) => void
+  } ?
+      LevelUpDel<K, O>:
+      LevelUpDel<any, AbstractDelOptions>;
+
+  export interface LevelUp<DB = AbstractLevelDOWN> extends EventEmitter {
+    open(): Promise<void>;
+    open(callback?: ErrorCallback): void;
+    close(): Promise<void>;
+    close(callback?: ErrorCallback): void;
+
+    put: InferDBPut<DB>;
+    get: InferDBGet<DB>;
+    del: InferDBDel<DB>;
+
+    batch(array: AbstractBatch[], options?: any): Promise<void>;
+    batch(array: AbstractBatch[], options: any, callback: (err?: any) => any):
+        void;
+    batch(array: AbstractBatch[], callback: (err?: any) => any): void;
+
+    batch(): LevelUpChain<any, any>;
+
+    isOpen(): boolean;
+    isClosed(): boolean;
+
+    createReadStream(options?: AbstractIteratorOptions<any>):
+        NodeJS.ReadableStream;
+    createKeyStream(options?: AbstractIteratorOptions<any>):
+        NodeJS.ReadableStream;
+    createValueStream(options?: AbstractIteratorOptions<any>):
+        NodeJS.ReadableStream;
+
+    /**emitted when a new value is 'put' */
+    on(event: 'put', cb: (key: any, value: any) => void): this
+        /**emitted when a value is deleted*/
+        on(event: 'del', cb: (key: any) => void): this
+        /**emitted when a batch operation has executed */
+        on(event: 'batch', cb: (ary: any[]) => void): this
+        /**emitted when the database has opened ('open' is synonym) */
+        on(event: 'ready', cb: () => void): this
+        /**emitted when the database has opened */
+        on(event: 'open', cb: () => void): this
+        /** emitted when the database has closed*/
+        on(event: 'closed', cb: () => void): this
+        /** emitted when the database is opening */
+        on(event: 'opening', cb: () => void): this
+        /** emitted when the database is closing */
+        on(event: 'closing', cb: () => void): this
+  }
+
+  interface LevelUpConstructor {
+    <DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+        db: DB, options: any, cb?: ErrorCallback): LevelUp<DB>;
+
+    <DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+        db: DB, cb?: ErrorCallback): LevelUp<DB>;
+
+    new<DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+        db: DB, options: any, cb?: ErrorCallback): LevelUp<DB>;
+
+    new<DB extends AbstractLevelDOWN = AbstractLevelDOWN>(
+        db: DB, cb?: ErrorCallback): LevelUp<DB>;
+
+    errors: typeof levelerrors;
+  }
+
+  export interface LevelUpChain<K = any, V = any> {
+    readonly length: number;
+    put(key: K, value: V): this;
+    del(key: K): this;
+    clear(): this;
+    write(callback: ErrorCallback): this;
+    write(): Promise<this>;
+  }
+
+  export var errors: typeof levelerrors;
+
+  const LevelUp: LevelUpConstructor;
+  export default LevelUp;
+}

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -56,6 +56,17 @@ export type TensorJson = {
   dtype?: tf.DataType
 };
 
+export type ModelJson = {
+  vars: TensorJson[]
+};
+
+export type UpdateJson = {
+  numExamples: number,
+  vars: TensorJson[],
+  modelId?: string,
+  clientId?: string
+};
+
 export async function tensorToJson(t: tf.Tensor): Promise<TensorJson> {
   let data;
   if (t instanceof LayerVariable) {

--- a/src/server/comm.ts
+++ b/src/server/comm.ts
@@ -16,18 +16,12 @@
  */
 
 import {ModelFitConfig} from '@tensorflow/tfjs';
-import * as fs from 'fs';
-import * as path from 'path';
 import {Server, Socket} from 'socket.io';
-import {promisify} from 'util';
-import * as uuid from 'uuid/v4';
 
 import {DownloadMsg, Events, UploadMsg} from '../common';
 import {serializedToJson, serializeVar} from '../serialization';
 
 import {ModelDB} from './model_db';
-
-const writeFile = promisify(fs.writeFile);
 
 export class SocketAPI {
   modelDB: ModelDB;
@@ -59,24 +53,20 @@ export class SocketAPI {
       // When a client sends us updated weights
       socket.on(Events.Upload, async (msg: UploadMsg, ack) => {
         // Save them to a file
-        const modelId = msg.modelId;
-        const updateId = uuid();
-        const updatePath =
-            path.join(this.modelDB.dataDir, modelId, updateId + '.json');
         const updatedVars = await Promise.all(msg.vars.map(serializedToJson));
-        const updateJSON = JSON.stringify({
+        const update = {
           clientId: socket.client.id,
-          modelId,
+          modelId: msg.modelId,
           numExamples: msg.numExamples,
           vars: updatedVars
-        });
-        await writeFile(updatePath, updateJSON);
+        };
+        await this.modelDB.putUpdate(update);
 
         // Let them know we're done saving
         ack(true);
 
         // Potentially update the model (asynchronously)
-        if (modelId === this.modelDB.modelId) {
+        if (msg.modelId === this.modelDB.modelId) {
           const updated = await this.modelDB.possiblyUpdate();
           if (updated) {
             // Send new variables to all clients if we updated

--- a/src/server/model_db.ts
+++ b/src/server/model_db.ts
@@ -16,41 +16,20 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
-import * as fs from 'fs';
-import * as path from 'path';
-import {promisify} from 'util';
+import EncodingDown from 'encoding-down';
+import LevelDown from 'leveldown';
+import LevelUp from 'levelup';
+import {LevelUp as LevelDB} from 'levelup';
+import * as uuid from 'uuid/v4';
 
 import {Model} from '../model';
-import {jsonToTensor, TensorJson, tensorToJson} from '../serialization';
+// tslint:disable-next-line:max-line-length
+import {jsonToTensor, ModelJson, TensorJson, tensorToJson, UpdateJson} from '../serialization';
 
 const DEFAULT_MIN_UPDATES = 10;
-const mkdir = promisify(fs.mkdir);
-const exists = promisify(fs.exists);
-const readdir = promisify(fs.readdir);
-const readFile = promisify(fs.readFile);
-const writeFile = promisify(fs.writeFile);
-
-async function getLatestId(dir: string) {
-  const files = await readdir(dir);
-  let latestId: string = null;
-  files.forEach((name) => {
-    if (name.endsWith('.json')) {
-      const id = name.slice(0, -5);
-      if (latestId == null || id > latestId) {
-        latestId = id;
-      }
-    }
-  });
-  return latestId;
-}
 
 function generateNewId() {
   return new Date().getTime().toString();
-}
-
-async function readJSON(path: string) {
-  const buffer = await readFile(path);
-  return JSON.parse(buffer.toString());
 }
 
 export class ModelDB {
@@ -58,6 +37,7 @@ export class ModelDB {
   modelId: string;
   updating: boolean;
   minUpdates: number;
+  db: LevelDB;
 
   constructor(dataDir: string, minUpdates?: number) {
     this.dataDir = dataDir;
@@ -67,35 +47,57 @@ export class ModelDB {
   }
 
   async setup() {
-    const dirExists = await exists(this.dataDir);
-    if (!dirExists) {
-      await mkdir(this.dataDir);
-    }
-
-    this.modelId = await getLatestId(this.dataDir);
-    if (this.modelId == null) {
+    this.db = await LevelUp(
+        EncodingDown(LevelDown(this.dataDir), {valueEncoding: 'json'}));
+    try {
+      this.modelId = await this.db.get('currentModelId');
+    } catch {
       const model = new Model();
       const dict = await model.setup();
       await this.writeNewVars(dict.vars as tf.Tensor[]);
     }
   }
 
-  async listUpdateFiles(): Promise<string[]> {
-    const files = await readdir(path.join(this.dataDir, this.modelId));
-    return files.map((f) => {
-      return path.join(this.dataDir, this.modelId, f);
-    });
+  async putUpdate(update: UpdateJson): Promise<void> {
+    return this.db.put(update.modelId + '/' + uuid(), update);
+  }
+
+  async getUpdates(): Promise<UpdateJson[]> {
+    const min = this.modelId;
+    const max = (parseInt(min, 10) + 1).toString();
+    return new Promise((resolve, reject) => {
+             const updates: UpdateJson[] = [];
+             this.db.createValueStream({gt: min, lt: max})
+                 .on('data', (data: UpdateJson) => updates.push(data))
+                 .on('error', (error) => reject(error))
+                 .on('end', () => resolve(updates));
+           }) as Promise<UpdateJson[]>;
+  }
+
+  async countUpdates(): Promise<number> {
+    const min = this.modelId;
+    const max = (parseInt(min, 10) + 1).toString();
+    return new Promise((resolve, reject) => {
+             let numUpdates = 0;
+             this.db.createKeyStream({gt: min, lt: max})
+                 .on('data', (key) => numUpdates++)
+                 .on('error', (error) => reject(error))
+                 .on('end', () => resolve(numUpdates));
+           }) as Promise<number>;
+  }
+
+  async getModelVars(modelId: string): Promise<tf.Tensor[]> {
+    const model: ModelJson = await this.db.get(modelId);
+    return model.vars.map(jsonToTensor);
   }
 
   async currentVars(): Promise<tf.Tensor[]> {
-    const file = path.join(this.dataDir, this.modelId + '.json');
-    const json = await readJSON(file);
-    return json['vars'].map(jsonToTensor);
+    return this.getModelVars(this.modelId);
   }
 
   async possiblyUpdate(): Promise<boolean> {
-    const updateFiles = await this.listUpdateFiles();
-    if (updateFiles.length < this.minUpdates || this.updating) {
+    const numUpdates = await this.countUpdates();
+    if (numUpdates < this.minUpdates || this.updating) {
       return false;
     }
     this.updating = true;
@@ -107,21 +109,20 @@ export class ModelDB {
   async update() {
     const currentVars = await this.currentVars();
     const updatedVars = currentVars.map(v => tf.zerosLike(v));
-    const updateFiles = await this.listUpdateFiles();
-    const updatesJSON = await Promise.all(updateFiles.map(readJSON));
+    const updatesJSON = await this.getUpdates();
 
     // Compute total number of examples for normalization
     let totalNumExamples = 0;
     updatesJSON.forEach((obj) => {
-      totalNumExamples += obj['numExamples'];
+      totalNumExamples += obj.numExamples;
     });
     const n = tf.scalar(totalNumExamples);
 
     // Apply normalized updates
     updatesJSON.forEach((u) => {
-      const nk = tf.scalar(u['numExamples']);
+      const nk = tf.scalar(u.numExamples);
       const frac = nk.div(n);
-      u['vars'].forEach((v: TensorJson, i: number) => {
+      u.vars.forEach((v: TensorJson, i: number) => {
         const update = jsonToTensor(v).mul(frac);
         updatedVars[i] = updatedVars[i].add(update);
       });
@@ -133,12 +134,9 @@ export class ModelDB {
 
   async writeNewVars(newVars: tf.Tensor[]) {
     const newModelId = generateNewId();
-    const newModelDir = path.join(this.dataDir, newModelId);
-    const newModelPath = path.join(this.dataDir, newModelId + '.json');
-    const newVarsJSON = await Promise.all(newVars.map(tensorToJson));
-    const newModelJSON = JSON.stringify({'vars': newVarsJSON});
-    await writeFile(newModelPath, newModelJSON);
-    await mkdir(newModelDir);
+    const newVarsJson = await Promise.all(newVars.map(tensorToJson));
+    await this.db.put(newModelId, {'vars': newVarsJson});
+    await this.db.put('currentModelId', newModelId);
     this.modelId = newModelId;
   }
 }

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -15,10 +15,15 @@
  * =============================================================================
  */
 
+import * as tf from '@tensorflow/tfjs';
 import {test_util} from '@tensorflow/tfjs-core';
+import EncodingDown from 'encoding-down';
 import * as fs from 'fs';
-import * as path from 'path';
+import LevelDown from 'leveldown';
+import LevelUp from 'levelup';
 import * as rimraf from 'rimraf';
+
+import {tensorToJson} from '../serialization';
 
 import {ModelDB} from './model_db';
 
@@ -28,38 +33,28 @@ const updateId2 = 'cdd749c0-8908-48d7-ba87-4844c831945c';
 
 describe('ModelDB', () => {
   let dataDir: string;
-  let modelDir: string;
-  let modelPath: string;
-  let updatePath1: string;
-  let updatePath2: string;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     dataDir = fs.mkdtempSync('/tmp/modeldb_test');
-    modelDir = path.join(dataDir, modelId);
-    modelPath = path.join(dataDir, modelId + '.json');
-    updatePath1 = path.join(modelDir, updateId1 + '.json');
-    updatePath2 = path.join(modelDir, updateId2 + '.json');
-    fs.mkdirSync(modelDir);
-    fs.writeFileSync(modelPath, JSON.stringify({
-      vars: [
-        {values: [0, 0, 0, 0], shape: [2, 2]},
-        {values: [1, 2, 3, 4], shape: [1, 4]}
-      ]
-    }));
-    fs.writeFileSync(updatePath1, JSON.stringify({
-      numExamples: 2,
-      vars: [
-        {values: [1, -1, 0, 0], shape: [2, 2]},
-        {values: [-1, -1, -1, -1], shape: [1, 4]}
-      ]
-    }));
-    fs.writeFileSync(updatePath2, JSON.stringify({
-      numExamples: 3,
-      vars: [
-        {values: [0, 0, 1, -1], shape: [2, 2]},
-        {values: [1, 2, 1, 2], shape: [1, 4]}
-      ]
-    }));
+    const lvl =
+        LevelUp(EncodingDown(LevelDown(dataDir), {valueEncoding: 'json'}));
+    await lvl.put('currentModelId', modelId);
+    const modelVars = await Promise.all([
+      tensorToJson(tf.tensor([0, 0, 0, 0], [2, 2])),
+      tensorToJson(tf.tensor([1, 2, 3, 4], [1, 4]))
+    ]);
+    const update1 = await Promise.all([
+      tensorToJson(tf.tensor([1, -1, 0, 0], [2, 2])),
+      tensorToJson(tf.tensor([-1, -1, -1, -1], [1, 4]))
+    ]);
+    const update2 = await Promise.all([
+      tensorToJson(tf.tensor([0, 0, 1, -1], [2, 2])),
+      tensorToJson(tf.tensor([1, 2, 1, 2], [1, 4]))
+    ]);
+    await lvl.put(modelId, {'vars': modelVars});
+    await lvl.put(modelId + '/' + updateId1, {numExamples: 2, vars: update1});
+    await lvl.put(modelId + '/' + updateId2, {numExamples: 3, vars: update2});
+    await lvl.close();
   });
 
   afterEach(() => {
@@ -100,21 +95,20 @@ describe('ModelDB', () => {
     let updated = await db.possiblyUpdate();
     expect(updated).toBe(false);
     expect(db.modelId).toBe(modelId);
-    const oldUpdateFiles = await db.listUpdateFiles();
-    expect(oldUpdateFiles.length).toBe(2);
+    const oldUpdateCount = await db.countUpdates();
+    expect(oldUpdateCount).toBe(2);
     const updateId3 = 'not-necessarily-a-uuid';
-    const updatePath3 = path.join(modelDir, updateId3 + '.json');
-    fs.writeFileSync(updatePath3, JSON.stringify({
+    await db.db.put(modelId + '/' + updateId3, {
       numExamples: 3,
       vars: [
-        {values: [0, 0, 0, 0], shape: [2, 2]},
-        {values: [0, 0, 0, 0], shape: [1, 4]}
+        tensorToJson(tf.tensor([0, 0, 0, 0], [2, 2])),
+        tensorToJson(tf.tensor([0, 0, 0, 0], [1, 4]))
       ]
-    }));
+    });
     updated = await db.possiblyUpdate();
     expect(updated).toBe(true);
     expect(db.modelId).not.toBe(modelId);
-    const newUpdateFiles = await db.listUpdateFiles();
-    expect(newUpdateFiles.length).toBe(0);
+    const newUpdateCount = await db.countUpdates();
+    expect(newUpdateCount).toBe(0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -180,6 +180,12 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
 
+abstract-leveldown@^5.0.0, abstract-leveldown@~5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz#f7128e1f86ccabf7d2893077ce5d06d798e386c6"
+  dependencies:
+    xtend "~4.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"
@@ -195,6 +201,10 @@ ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -208,6 +218,17 @@ ansi-styles@^3.2.1:
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
+
+aproba@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+
+are-we-there-yet@~1.1.2:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz#4b35c2944f062a8bfcda66410760350fe9ddfc21"
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
 
 array-find-index@^1.0.1:
   version "1.0.2"
@@ -263,6 +284,17 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
+bindings@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
+bl@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
+  dependencies:
+    readable-stream "^2.3.5"
+    safe-buffer "^5.1.1"
+
 blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
@@ -288,6 +320,21 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+
+buffer-alloc@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
 
 buffer-from@^1.0.0:
   version "1.1.0"
@@ -341,6 +388,10 @@ chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chownr@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+
 clang-format@~1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.2.3.tgz#2763561aa7449c43737480f8df3a2b5b66e6cf37"
@@ -361,6 +412,10 @@ cli-usage@^0.1.1:
   dependencies:
     marked "^0.3.12"
     marked-terminal "^2.0.0"
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 color-convert@^1.9.0:
   version "1.9.1"
@@ -396,6 +451,10 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
 content-disposition@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
@@ -411,6 +470,10 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+core-util-is@~1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -445,6 +508,27 @@ decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+
+deferred-leveldown@~4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-4.0.2.tgz#0b0570087827bf480a23494b398f04c128c19a20"
+  dependencies:
+    abstract-leveldown "~5.0.0"
+    inherits "^2.0.3"
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+
 depd@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
@@ -456,6 +540,10 @@ depd@~1.1.1, depd@~1.1.2:
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
@@ -474,6 +562,22 @@ ee-first@1.1.1:
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
+
+encoding-down@^5.0.3, encoding-down@~5.0.0:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/encoding-down/-/encoding-down-5.0.3.tgz#b2b2305b2b810ff6d0bda85583bfc71bda56dc49"
+  dependencies:
+    abstract-leveldown "^5.0.0"
+    inherits "^2.0.3"
+    level-codec "^9.0.0"
+    level-errors "^2.0.0"
+    xtend "^4.0.1"
+
+end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
+  dependencies:
+    once "^1.4.0"
 
 engine.io-client@~3.2.0:
   version "3.2.1"
@@ -512,6 +616,12 @@ engine.io@~3.2.0:
     engine.io-parser "~2.1.0"
     ws "~3.3.1"
 
+errno@~0.1.1:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
+  dependencies:
+    prr "~1.0.1"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -541,6 +651,10 @@ esutils@^2.0.2:
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+
+expand-template@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
 
 express@^4.16.3:
   version "4.16.3"
@@ -576,6 +690,10 @@ express@^4.16.3:
     type-is "~1.6.16"
     utils-merge "1.0.1"
     vary "~1.1.2"
+
+fast-future@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fast-future/-/fast-future-1.0.2.tgz#8435a9aaa02d79248d17d704e76259301d99280a"
 
 filewatcher@~3.0.0:
   version "3.0.1"
@@ -614,13 +732,34 @@ fresh@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
 
 glob@^7.0.0, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1:
   version "7.1.2"
@@ -660,6 +799,10 @@ has-cors@1.1.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
 hosted-git-info@^2.1.4:
   version "2.6.0"
@@ -704,9 +847,13 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+ini@~1.3.0:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 ipaddr.js@1.6.0:
   version "1.6.0"
@@ -728,6 +875,16 @@ is-finite@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  dependencies:
+    number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-object@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-0.1.2.tgz#00efbc08816c33cfc4ac8251d132e10dc65098d7"
@@ -743,6 +900,10 @@ is@~0.2.6:
 isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -762,6 +923,62 @@ jasmine@^3.1.0:
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
+level-codec@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-9.0.0.tgz#2d3a0e835c4aa8339ec63de3f5a37480b74a5f87"
+
+level-errors@^2.0.0, level-errors@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/level-errors/-/level-errors-2.0.0.tgz#2de5b566b62eef92f99e19be74397fbc512563fa"
+  dependencies:
+    errno "~0.1.1"
+
+level-iterator-stream@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/level-iterator-stream/-/level-iterator-stream-2.0.1.tgz#3ef8309d238578cd8730b2a15b764f26862d9e63"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.5"
+    xtend "^4.0.0"
+
+level-packager@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/level-packager/-/level-packager-3.1.0.tgz#e617c8633d6ecc2ed40c56d86b75464392fa3ccd"
+  dependencies:
+    encoding-down "~5.0.0"
+    levelup "^3.0.0"
+
+"level-typings@git+https://github.com/Level/typings.git":
+  version "0.1.0"
+  resolved "git+https://github.com/Level/typings.git#6ad3a7d0f4dfea2ddf30556735b1fd10aedad201"
+
+level@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/level/-/level-4.0.0.tgz#86aa46b5430bac12676e693ebff206232ef1e549"
+  dependencies:
+    level-packager "^3.0.0"
+    leveldown "^4.0.0"
+    opencollective-postinstall "^2.0.0"
+
+leveldown@^4.0.0, leveldown@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-4.0.1.tgz#7bc3df93c9fa574feb39ce45a0c4073aa948cfef"
+  dependencies:
+    abstract-leveldown "~5.0.0"
+    bindings "~1.3.0"
+    fast-future "~1.0.2"
+    nan "~2.10.0"
+    prebuild-install "^4.0.0"
+
+levelup@^3.0.0, levelup@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/levelup/-/levelup-3.0.1.tgz#07794639fd0af185089130aaea09d03023637b8d"
+  dependencies:
+    deferred-leveldown "~4.0.0"
+    level-errors "~2.0.0"
+    level-iterator-stream "~2.0.0"
+    xtend "~4.0.0"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -920,6 +1137,10 @@ mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
+
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -944,9 +1165,19 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
+nan@~2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
+
+node-abi@^2.2.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-2.4.1.tgz#7628c4d4ec4e9cd3764ceb3652f36b2e7f8d4923"
+  dependencies:
+    semver "^5.4.1"
 
 node-emoji@^1.4.1:
   version "1.8.1"
@@ -970,6 +1201,10 @@ node-notifier@^4.0.2:
     shellwords "^0.1.0"
     which "^1.0.5"
 
+noop-logger@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -979,11 +1214,20 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+npmlog@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4.0.1:
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -1005,11 +1249,19 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+opencollective-postinstall@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.0.tgz#5fe062f2706bb84150f7fb1af9f1277e46ec1388"
+
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
 parse-json@^2.2.0:
   version "2.2.0"
@@ -1073,6 +1325,30 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+prebuild-install@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-4.0.0.tgz#206ce8106ce5efa4b6cf062fc8a0a7d93c17f3a8"
+  dependencies:
+    detect-libc "^1.0.3"
+    expand-template "^1.0.2"
+    github-from-package "0.0.0"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    node-abi "^2.2.0"
+    noop-logger "^0.1.1"
+    npmlog "^4.0.1"
+    os-homedir "^1.0.1"
+    pump "^2.0.1"
+    rc "^1.1.6"
+    simple-get "^2.7.0"
+    tar-fs "^1.13.0"
+    tunnel-agent "^0.6.0"
+    which-pm-runs "^1.0.0"
+
+process-nextick-args@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
+
 protobufjs@~6.8.0:
   version "6.8.6"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.6.tgz#ce3cf4fff9625b62966c455fc4c15e4331a11ca2"
@@ -1097,6 +1373,24 @@ proxy-addr@~2.0.3:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.6.0"
+
+prr@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
+
+pump@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
+
+pump@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-2.0.1.tgz#12399add6e4cf7526d973cbc8b5ce2e2908b3909"
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@1.3.2:
   version "1.3.2"
@@ -1123,6 +1417,15 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
+rc@^1.1.6:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 read-pkg-up@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-1.0.1.tgz#9d63c13276c065918d57f002a57f40a1b643fb02"
@@ -1137,6 +1440,18 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.3.0, readable-stream@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 redent@^1.0.0:
   version "1.0.0"
@@ -1173,7 +1488,7 @@ safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@~5.1.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -1181,7 +1496,7 @@ seedrandom@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -1212,6 +1527,10 @@ serve-static@1.13.2:
     parseurl "~1.3.2"
     send "0.16.2"
 
+set-blocking@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
@@ -1227,6 +1546,18 @@ shellwords@^0.1.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-concat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
+
+simple-get@^2.7.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
+  dependencies:
+    decompress-response "^3.3.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 socket.io-adapter@~1.1.0:
   version "1.1.1"
@@ -1311,11 +1642,38 @@ statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
-strip-ansi@^3.0.0:
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  dependencies:
+    safe-buffer "~5.1.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -1333,7 +1691,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^2.0.0:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -1347,9 +1705,34 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+tar-fs@^1.13.0:
+  version "1.16.2"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.2.tgz#17e5239747e399f7e77344f5f53365f04af53577"
+  dependencies:
+    chownr "^1.0.1"
+    mkdirp "^0.5.1"
+    pump "^1.0.0"
+    tar-stream "^1.1.2"
+
+tar-stream@^1.1.2:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.1.tgz#f84ef1696269d6223ca48f6e1eeede3f7e81f395"
+  dependencies:
+    bl "^1.0.0"
+    buffer-alloc "^1.1.0"
+    end-of-stream "^1.0.0"
+    fs-constants "^1.0.0"
+    readable-stream "^2.3.0"
+    to-buffer "^1.1.0"
+    xtend "^4.0.0"
+
 to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
+
+to-buffer@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
 
 trim-newlines@^1.0.0:
   version "1.0.0"
@@ -1370,9 +1753,21 @@ ts-node-dev@^1.0.0-pre.26:
     ts-node "*"
     tsconfig "^7.0.0"
 
-ts-node@*, ts-node@^6.1.0:
+ts-node@*:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.1.0.tgz#a2c37a11fdb58e60eca887a1269b025cf4d2f8b8"
+  dependencies:
+    arrify "^1.0.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.5.6"
+    yn "^2.0.0"
+
+ts-node@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.1.1.tgz#19607140acb06150441fcdb61be11f73f7b6657e"
   dependencies:
     arrify "^1.0.0"
     diff "^3.1.0"
@@ -1417,6 +1812,12 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  dependencies:
+    safe-buffer "^5.0.1"
+
 type-is@~1.6.15, type-is@~1.6.16:
   version "1.6.16"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.16.tgz#f89ce341541c672b25ee7ae3c73dee3b2be50194"
@@ -1443,6 +1844,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
@@ -1458,11 +1863,21 @@ vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
+which-pm-runs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.0.0.tgz#670b3afbc552e0b55df6b7780ca74615f23ad1cb"
+
 which@^1.0.5:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  dependencies:
+    string-width "^1.0.2 || 2"
 
 wrappy@1:
   version "1.0.2"
@@ -1479,6 +1894,10 @@ ws@~3.3.1:
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz#c2876b06168aadc40e57d97e81191ac8f4398b3e"
+
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 xtend@~2.0.6:
   version "2.0.6"


### PR DESCRIPTION
https://github.com/google/leveldb is an awesome piece of software, and should hopefully both make our code faster now _and_ be scalable in case we ever need to be.

Main TODO: do some benchmarking to see if this is actually faster!

Secondary: To use the Node LevelDB client libraries in Typescript, I manually copy-pasted a few files from an experimental repo that implements them, https://github.com/Level/typings (and with Aman's expert help, made one small change to them to fix something that bothered `ts-node` though not `tsc`). Unfortunately we can't use the typings from DefinitelyTyped because they're very out of date and no longer compatible with recent versions of the LevelDB client libraries. If there's a better way we can deal with this, let me know!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/federated-learning/9)
<!-- Reviewable:end -->
