### PR TITLE
update server/client/model interfaces

### DIFF
--- a/audio_demo/index.js
+++ b/audio_demo/index.js
@@ -84,12 +84,13 @@ loadAudioTransferLearningModel().then(async (model) => {
   runOptions.frameMillis = runOptions.frameSize / runOptions.sampleRate * 1e3;
 
   const clientAPI = new ClientAPI(new FederatedTfModel(model));
-  await clientAPI.connectTo(serverURL);
-  clientAPI.onUpdate((msg) => {
+  clientAPI.onDownload((msg) => {
+    const newVersion = msg.modelVersion;
     console.log(
-        `new model! updating from ${modelVersion.innerText} to ${msg.modelId}`);
-    modelVersion.innerText = msg.modelId;
+        `new model! updating from ${modelVersion.innerText} to ${newVersion}`);
+    modelVersion.innerText = newVersion;
   });
+  await clientAPI.connect(serverURL);
 
   recordButton.innerHTML = 'Waiting for microphone&hellip;';
   const stream =

--- a/audio_demo/index.js
+++ b/audio_demo/index.js
@@ -18,7 +18,7 @@
 import * as tf from '@tensorflow/tfjs';
 import MediaStreamRecorder from 'msr';
 
-import * as client from '../src/client/client';
+import {ClientAPI} from '../src/client/client';
 import {AudioTransferLearningModel} from '../src/index';
 
 import {plotSpectrogram, plotSpectrum} from './spectral_plots';
@@ -77,21 +77,19 @@ const modelTemplate = `
 const serverURL = 'http://localhost:3000';
 const fedModel = new AudioTransferLearningModel();
 
-fedModel.setup().then(async (dict) => {
-  const model = dict.model;
+fedModel.setup().then(async () => {
+  const model = fedModel.model;
   const inputShape = model.inputs[0].shape;
   runOptions.numFrames = inputShape[1];
   runOptions.modelFFTLength = inputShape[2];
   runOptions.frameMillis = runOptions.frameSize / runOptions.sampleRate * 1e3;
-  const clientAPI = client.VariableSynchroniser.fromLayers(model.layers);
-  clientAPI.acceptUpdate = (msg) => {
+  const clientAPI = new ClientAPI(fedModel);
+  clientAPI.onUpdate((msg) => {
     console.log(
         `new model! updating from ${modelVersion.innerText} to ${msg.modelId}`);
     modelVersion.innerText = msg.modelId;
-    return true;
-  };
-  await clientAPI.initialise(serverURL);
-  modelVersion.innerText = clientAPI.modelId;
+  });
+  await clientAPI.setup(serverURL);
   recordButton.innerHTML = 'Waiting for microphone&hellip;';
   const stream =
       await navigator.mediaDevices.getUserMedia({audio: true, video: false});
@@ -250,9 +248,6 @@ function setupUI(stream, model, clientAPI) {
       }
       // dispose of tensors
       tf.dispose([x, y]);
-      // restore variables we had before training
-      clientAPI.revertToOriginalVars();
-      clientAPI.numExamples = 0;
       // decide what label to request next
       labelIdx += 1;
       if (labelIdx >= labelNames.length) {
@@ -274,19 +269,8 @@ function setupUI(stream, model, clientAPI) {
     recordButton.innerHTML = 'Uploading Data&hellip;'
     clientAPI.uploadData(x, y).then(() => {
       console.log('fitting model...');
-      const modelVersionBeforeFitting = clientAPI.modelId;
       recordButton.innerHTML = 'Fitting Model&hellip;'
-      model.fit(x, y, clientAPI.fitConfig).then(() => {
-        if (clientAPI.modelId === modelVersionBeforeFitting) {
-          console.log('uploading weights...');
-          clientAPI.numExamples = 1;
-          recordButton.innerHTML = 'Uploading Weights&hellip;'
-          clientAPI.uploadVars().then(cleanup, cleanup);
-        } else {
-          console.log('aborting weight upload due to version change!');
-          cleanup();
-        }
-      }, cleanup);
+      clientAPI.federatedUpdate(x, y).then(cleanup, cleanup);
     }, cleanup);
   }
 }

--- a/src/client/comm.ts
+++ b/src/client/comm.ts
@@ -86,12 +86,12 @@ export class ClientAPI {
     const msg = await this.connectTo(serverURL);
     this.msg = msg;
     this.setVars(msg.vars);
-    this.downloadCallbacks.forEach((cb) => cb(msg));
+    this.downloadCallbacks.forEach(cb => cb(msg));
 
     this.socket.on(Events.Download, (msg: DownloadMsg) => {
       this.msg = msg;
       this.setVars(msg.vars);
-      this.downloadCallbacks.forEach((cb) => cb(msg));
+      this.downloadCallbacks.forEach(cb => cb(msg));
     });
   }
 
@@ -166,7 +166,7 @@ export class ClientAPI {
 
   protected setVars(newVars: SerializedVariable[]) {
     tf.tidy(() => {
-      this.model.setVars(newVars.map(deserializeVar));
+      this.model.setVars(newVars.map(v => deserializeVar(v)));
     });
   }
 

--- a/src/client/comm.ts
+++ b/src/client/comm.ts
@@ -16,10 +16,6 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
-import {ModelFitConfig, Variable} from '@tensorflow/tfjs';
-import {assert} from '@tensorflow/tfjs-core/dist/util';
-import {Layer} from '@tensorflow/tfjs-layers/dist/engine/topology';
-import {LayerVariable} from '@tensorflow/tfjs-layers/dist/variables';
 import * as socketProxy from 'socket.io-client';
 // tslint:disable-next-line:no-angle-bracket-type-assertion no-any
 const socketio = (<any>socketProxy).default || socketProxy;
@@ -27,6 +23,7 @@ const socketio = (<any>socketProxy).default || socketProxy;
 import {DataMsg, DownloadMsg, Events, UploadMsg} from '../common';
 // tslint:disable-next-line:max-line-length
 import {deserializeVar, SerializedVariable, serializeVar, serializeVars} from '../serialization';
+import {FederatedModel} from '../types';
 
 const CONNECTION_TIMEOUT = 10 * 1000;
 const UPLOAD_TIMEOUT = 5 * 1000;
@@ -54,37 +51,25 @@ const UPLOAD_TIMEOUT = 5 * 1000;
  * broadcasts weights.
  * The client->server sync must be triggered manually with uploadVars
  */
-export class VariableSynchroniser {
-  public modelId: string;
-  public numExamples: number;
-  public fitConfig: ModelFitConfig;
-  public acceptUpdate: (msg: DownloadMsg) => boolean;
+
+type UpdateCallback = (msg: DownloadMsg) => void;
+
+export class ClientAPI {
+  public model: FederatedModel;
+  public msg: DownloadMsg;
   private socket: SocketIOClient.Socket;
-  private vars: Array<Variable|LayerVariable>;
-  private msg: DownloadMsg;
+  private updateCallbacks: UpdateCallback[];
   /**
    * Construct a synchroniser from a list of tf.Variables of tf.LayerVariables.
    * @param {Array<Variable|LayerVariable>} vars - Variables to track and sync
    */
-  constructor(
-      vars: Array<Variable|LayerVariable>,
-      updateCallback?: (msg: DownloadMsg) => boolean) {
-    this.vars = vars;
-    if (updateCallback) {
-      this.acceptUpdate = updateCallback;
-    } else {
-      this.acceptUpdate = () => true;
-    }
+  constructor(model: FederatedModel) {
+    this.model = model;
+    this.updateCallbacks = [];
   }
 
-  /**
-   * Construct a VariableSynchroniser from an array of layers.
-   * This will synchronise the weights of the layers.
-   * @param layers: An array of layers to extract variables from
-   */
-  public static fromLayers(layers: Layer[]) {
-    const layerWeights = layers.map(l => l.trainableWeights);
-    return new VariableSynchroniser(tf.util.flatten(layerWeights, []));
+  public onUpdate(callback: UpdateCallback) {
+    this.updateCallbacks.push(callback);
   }
 
   private async connect(url: string): Promise<DownloadMsg> {
@@ -100,28 +85,25 @@ export class VariableSynchroniser {
    * @return A promise that resolves when the connection has been established
    * and variables set to their inital values.
    */
-  public async initialise(url: string): Promise<ModelFitConfig> {
-    const connMsg = await this.connect(url);
-    this.setVarsFromMessage(connMsg.vars);
-    this.modelId = connMsg.modelId;
-    this.fitConfig = connMsg.fitConfig;
-    this.numExamples = 0;
-    this.msg = connMsg;
+  public async setup(url: string): Promise<void> {
+    this.msg = await this.connect(url);
+    this.setVarsFromMessage(this.msg.vars);
+    for (let i = 0; i < this.updateCallbacks.length; i++) {
+      this.updateCallbacks[i](this.msg);
+    }
 
     this.socket.on(Events.Download, (msg: DownloadMsg) => {
-      if (this.acceptUpdate(msg)) {
-        this.msg = msg;
-        this.setVarsFromMessage(msg.vars);
-        this.modelId = msg.modelId;
-        this.fitConfig = {...msg.fitConfig};
-        this.numExamples = 0;
+      this.msg = msg;
+      this.setVarsFromMessage(msg.vars);
+      for (let i = 0; i < this.updateCallbacks.length; i++) {
+        this.updateCallbacks[i](this.msg);
       }
     });
-
-    return {...this.fitConfig};
   }
 
   /**
+   * TODO: remove this method, move functionality to specific demos
+   *
    * Upload x and y tensors to the server (for debugging/training)
    * @return A promise that resolves when the server has recieved the data
    */
@@ -140,11 +122,35 @@ export class VariableSynchroniser {
   }
 
   /**
+   * Train the model on the given examples, upload new weights to the server,
+   * then revert back to the original weights (so subsequent updates are
+   * relative to the same model).
+   *
+   * TODO: consider having this method save copies of `xs` and `ys` when there
+   * are too few examples, and only doing training/uploading after reaching a
+   * configurable threshold (disposing of the copies afterwards).
+   *
+   * @param xs Training inputs
+   * @param ys Training labels
+   */
+  public async federatedUpdate(xs: tf.Tensor, ys: tf.Tensor): Promise<void> {
+    // save original model ID (in case it changes during training/serialization)
+    const modelId = this.msg.modelId;
+    // fit the model to the new data
+    await this.model.fit(xs, ys, this.msg.fitConfig);
+    // serialize the new weights -- in the future we could add noise here
+    const newVars = await serializeVars(this.model.getVars());
+    // revert our model back to its original weights
+    this.setVarsFromMessage(this.msg.vars);
+    // upload the updates to the server
+    await this.uploadVars({modelId, numExamples: xs.shape[0], vars: newVars});
+  }
+
+  /**
    * Upload the current values of the tracked variables to the server
    * @return A promise that resolves when the server has recieved the variables
    */
-  public async uploadVars(): Promise<{}> {
-    const msg: UploadMsg = await this.serializeCurrentVars();
+  private async uploadVars(msg: UploadMsg): Promise<{}> {
     const prom = new Promise((resolve, reject) => {
       const rejectTimer =
           setTimeout(() => reject(`uploadVars timed out`), UPLOAD_TIMEOUT);
@@ -156,40 +162,10 @@ export class VariableSynchroniser {
     return prom;
   }
 
-  /**
-   * Restore variables to their original values (e.g. before training),
-   * which is necessary if a single client sends multiple updates for different
-   * (sets of) examples.
-   */
-  public revertToOriginalVars() {
-    this.setVarsFromMessage(this.msg.vars);
-  }
-
-  protected async serializeCurrentVars(): Promise<UploadMsg> {
-    assert(this.numExamples > 0, 'should only serialize if we\'ve seen data');
-
-    const vars = await serializeVars(this.vars);
-
-    return {
-      numExamples: this.numExamples, /* TODO: ensure this gets updated */
-      modelId: this.modelId,
-      vars
-    };
-  }
-
   protected setVarsFromMessage(newVars: SerializedVariable[]) {
-    for (let i = 0; i < newVars.length; i++) {
-      const newVar = newVars[i];
-      // tslint:disable-next-line:no-any
-      const varOrLVar = (this.vars[i] as any);
-      const newVal = deserializeVar(newVar);
-      if (varOrLVar.write != null) {
-        varOrLVar.write(newVal);
-      } else {
-        varOrLVar.assign(newVal);
-      }
-      newVal.dispose();
-    }
+    tf.tidy(() => {
+      this.model.setVars(newVars.map(deserializeVar));
+    });
   }
 
   public dispose() {

--- a/src/comm_test.ts
+++ b/src/comm_test.ts
@@ -17,7 +17,7 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
-import {test_util, Variable} from '@tensorflow/tfjs';
+import {ModelFitConfig, Tensor, test_util, Variable} from '@tensorflow/tfjs';
 import EncodingDown from 'encoding-down';
 import * as fs from 'fs';
 import * as http from 'http';
@@ -26,10 +26,11 @@ import LevelUp from 'levelup';
 import * as rimraf from 'rimraf';
 import * as serverSocket from 'socket.io';
 
-import {VariableSynchroniser} from './client/comm';
+import {ClientAPI} from './client/comm';
 import {tensorToJson} from './serialization';
-import {SocketAPI} from './server/comm';
+import {ServerAPI} from './server/comm';
 import {ModelDB} from './server/model_db';
+import {FederatedModel, VarList} from './types';
 
 const modelId = '1528400733553';
 const batchSize = 42;
@@ -50,11 +51,28 @@ function waitUntil(done: () => boolean, then: () => void, timeout?: number) {
   const moveOnAnyway = setTimeout(moveOn, timeout || 100);
 }
 
+class MockModel implements FederatedModel {
+  vars: Variable[];
+  constructor(vars: Variable[]) {
+    this.vars = vars;
+  }
+  async setup() {}
+  async fit(x: Tensor, y: Tensor, fitConfig: ModelFitConfig) {}
+  setVars(vars: Tensor[]) {
+    for (let i = 0; i < this.vars.length; i++) {
+      this.vars[i].assign(vars[i]);
+    }
+  }
+  getVars(): VarList {
+    return this.vars;
+  }
+}
+
 describe('Socket API', () => {
   let dataDir: string;
   let modelDB: ModelDB;
-  let serverAPI: SocketAPI;
-  let clientAPI: VariableSynchroniser;
+  let serverAPI: ServerAPI;
+  let clientAPI: ClientAPI;
   let clientVars: Variable[];
   let httpServer: http.Server;
 
@@ -73,14 +91,15 @@ describe('Socket API', () => {
 
     // Set up the server exposing our upload/download API
     httpServer = http.createServer();
-    serverAPI = new SocketAPI(modelDB, FIT_CONFIG, serverSocket(httpServer));
+    serverAPI = new ServerAPI(modelDB, FIT_CONFIG, serverSocket(httpServer));
     await serverAPI.setup();
     await httpServer.listen(PORT);
 
     // Set up the API client with zeroed out weights
     clientVars = initWeights.map(t => tf.variable(tf.zerosLike(t)));
-    clientAPI = new VariableSynchroniser(clientVars);
-    await clientAPI.initialise(socketURL);
+    const model = new MockModel(clientVars);
+    clientAPI = new ClientAPI(model);
+    await clientAPI.setup(socketURL);
   });
 
   afterEach(async () => {
@@ -89,11 +108,11 @@ describe('Socket API', () => {
   });
 
   it('transmits fit config on startup', () => {
-    expect(clientAPI.fitConfig.batchSize).toBe(batchSize);
+    expect(clientAPI.msg.fitConfig.batchSize).toBe(batchSize);
   });
 
   it('transmits model version on startup', () => {
-    expect(clientAPI.modelId).toBe(modelId);
+    expect(clientAPI.msg.modelId).toBe(modelId);
   });
 
   it('transmits model parameters on startup', () => {
@@ -106,30 +125,31 @@ describe('Socket API', () => {
     expect(numUpdates).toBe(0);
 
     clientVars[0].assign(tf.tensor([2, 2, 2, 2], [2, 2]));
-    clientAPI.numExamples = 1;
-    await clientAPI.uploadVars();
+    const dummyX = tf.tensor2d([[0], [0]]);
+    const dummyY = tf.tensor1d([0]);
+    await clientAPI.federatedUpdate(dummyX, dummyY);
 
     numUpdates = await modelDB.countUpdates();
     expect(numUpdates).toBe(1);
   });
 
   it('triggers a download after enough uploads', async (done) => {
+    const dummyX1 = tf.tensor2d([[0]]);            // 1 example
+    const dummyX3 = tf.tensor2d([[0], [0], [0]]);  // 3 examples
+    const dummyY = tf.tensor1d([0]);
     clientVars[0].assign(tf.tensor([2, 2, 2, 2], [2, 2]));
-    clientAPI.numExamples = 1;
-    await clientAPI.uploadVars();
+    await clientAPI.federatedUpdate(dummyX1, dummyY);
 
     clientVars[0].assign(tf.tensor([1, 1, 1, 1], [2, 2]));
     clientVars[1].assign(tf.tensor([4, 3, 2, 1], [1, 4]));
-    clientAPI.numExamples = 3;
-    await clientAPI.uploadVars();
+    await clientAPI.federatedUpdate(dummyX3, dummyY);
 
-    waitUntil(() => clientAPI.modelId !== modelId, () => {
+    waitUntil(() => clientAPI.msg.modelId !== modelId, () => {
       test_util.expectArraysClose(
           clientVars[0], tf.tensor([1.25, 1.25, 1.25, 1.25], [2, 2]));
       test_util.expectArraysClose(
           clientVars[1], tf.tensor([3.25, 2.75, 2.25, 1.75], [1, 4]));
-      expect(clientAPI.numExamples).toBe(0);
-      expect(clientAPI.modelId).toBe(modelDB.modelId);
+      expect(clientAPI.msg.modelId).toBe(modelDB.modelId);
       done();
     });
   });

--- a/src/common.ts
+++ b/src/common.ts
@@ -25,7 +25,7 @@ export enum Events {
 }
 
 export type UploadMsg = {
-  modelId: string,
+  modelVersion: string,
   vars: SerializedVariable[],
   numExamples: number
 };
@@ -36,6 +36,6 @@ export type DataMsg = {
 };
 
 export type DownloadMsg = {
-  modelId: string,
+  modelVersion: string,
   vars: SerializedVariable[]
 };

--- a/src/common.ts
+++ b/src/common.ts
@@ -16,7 +16,6 @@
  */
 
 /** Shared between client and server */
-import {ModelFitConfig} from '@tensorflow/tfjs';
 import {SerializedVariable} from './serialization';
 
 export enum Events {
@@ -39,5 +38,4 @@ export type DataMsg = {
 export type DownloadMsg = {
   modelId: string,
   vars: SerializedVariable[]
-  fitConfig: ModelFitConfig,
 };

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -65,7 +65,7 @@ export type ModelJson = {
 export type UpdateJson = {
   numExamples: number,
   vars: TensorJson[],
-  modelId?: string,
+  modelVersion?: string,
   clientId?: string
 };
 

--- a/src/server/audio_demo_server.ts
+++ b/src/server/audio_demo_server.ts
@@ -16,9 +16,12 @@
  */
 
 import * as path from 'path';
-import {AudioTransferLearningModel} from '../index';
+import {FederatedTfModel, loadAudioTransferLearningModel} from '../index';
 import {setup} from './server';
 
 const dataDir = path.resolve(__dirname + '/../../data');
-const model = new AudioTransferLearningModel();
-setup(model, dataDir);
+
+loadAudioTransferLearningModel().then((tfModel) => {
+  const fedModel = new FederatedTfModel(tfModel);
+  setup(fedModel, dataDir);
+});

--- a/src/server/comm.ts
+++ b/src/server/comm.ts
@@ -23,7 +23,7 @@ import {serializedToJson, serializeVar} from '../serialization';
 
 import {ModelDB} from './model_db';
 
-export class SocketAPI {
+export class ServerAPI {
   modelDB: ModelDB;
   fitConfig: ModelFitConfig;
   io: Server;

--- a/src/server/comm.ts
+++ b/src/server/comm.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 
-import {ModelFitConfig} from '@tensorflow/tfjs';
 import {Server, Socket} from 'socket.io';
 
 import {DataMsg, DownloadMsg, Events, UploadMsg} from '../common';
@@ -25,15 +24,13 @@ import {ModelDB} from './model_db';
 
 export class ServerAPI {
   modelDB: ModelDB;
-  fitConfig: ModelFitConfig;
   io: Server;
   numClients = 0;
 
   constructor(
-      modelDB: ModelDB, fitConfig: ModelFitConfig, io: Server,
+      modelDB: ModelDB, io: Server,
       private exitOnClientExit = false) {
     this.modelDB = modelDB;
-    this.fitConfig = fitConfig;
     this.io = io;
   }
 
@@ -41,7 +38,6 @@ export class ServerAPI {
     const varsJson = await this.modelDB.currentVars();
     const varsSeri = await Promise.all(varsJson.map(serializeVar));
     return {
-      fitConfig: this.fitConfig,
       modelId: this.modelDB.modelId,
       vars: varsSeri
     };

--- a/src/server/model_db.ts
+++ b/src/server/model_db.ts
@@ -28,37 +28,36 @@ import {FederatedModel} from '../types';
 
 const DEFAULT_MIN_UPDATES = 5;
 
-function generateNewId() {
+function currentTimestamp() {
   return new Date().getTime().toString();
 }
 
 export class ModelDB {
   dataDir: string;
-  modelId: string;
+  modelVersion: string;
   updating: boolean;
   minUpdates: number;
   db: LevelDB;
 
   constructor(dataDir: string, minUpdates?: number) {
     this.dataDir = dataDir;
-    this.modelId = null;
     this.updating = false;
     this.minUpdates = minUpdates || DEFAULT_MIN_UPDATES;
+    this.modelVersion = null;
   }
 
   async setup(model?: FederatedModel) {
     this.db = await LevelUp(
         EncodingDown(LevelDown(this.dataDir), {valueEncoding: 'json'}));
     try {
-      this.modelId = await this.db.get('currentModelId');
+      this.modelVersion = await this.db.get('currentModelVersion');
     } catch {
-      await model.setup();
       await this.writeNewVars(model.getVars() as tf.Tensor[]);
     }
   }
 
   async putData(data: DataJson): Promise<void> {
-    return this.db.put('data/' + generateNewId() + '_' + uuid(), data);
+    return this.db.put('data/' + currentTimestamp() + '_' + uuid(), data);
   }
 
   async getData(): Promise<DataJson[]> {
@@ -72,11 +71,11 @@ export class ModelDB {
   }
 
   async putUpdate(update: UpdateJson): Promise<void> {
-    return this.db.put(update.modelId + '/' + uuid(), update);
+    return this.db.put(update.modelVersion + '/' + uuid(), update);
   }
 
   async getUpdates(): Promise<UpdateJson[]> {
-    const min = this.modelId;
+    const min = this.modelVersion;
     const max = (parseInt(min, 10) + 1).toString();
     return new Promise((resolve, reject) => {
              const updates: UpdateJson[] = [];
@@ -88,7 +87,7 @@ export class ModelDB {
   }
 
   async countUpdates(): Promise<number> {
-    const min = this.modelId;
+    const min = this.modelVersion;
     const max = (parseInt(min, 10) + 1).toString();
     return new Promise((resolve, reject) => {
              let numUpdates = 0;
@@ -99,13 +98,13 @@ export class ModelDB {
            }) as Promise<number>;
   }
 
-  async getModelVars(modelId: string): Promise<tf.Tensor[]> {
-    const model: ModelJson = await this.db.get(modelId);
+  async getModelVars(modelVersion: string): Promise<tf.Tensor[]> {
+    const model: ModelJson = await this.db.get(modelVersion);
     return model.vars.map(jsonToTensor);
   }
 
   async currentVars(): Promise<tf.Tensor[]> {
-    return this.getModelVars(this.modelId);
+    return this.getModelVars(this.modelVersion);
   }
 
   async possiblyUpdate(): Promise<boolean> {
@@ -146,10 +145,10 @@ export class ModelDB {
   }
 
   async writeNewVars(newVars: tf.Tensor[]) {
-    const newModelId = generateNewId();
+    const newModelVersion = currentTimestamp();
     const newVarsJson = await Promise.all(newVars.map(tensorToJson));
-    await this.db.put(newModelId, {'vars': newVarsJson});
-    await this.db.put('currentModelId', newModelId);
-    this.modelId = newModelId;
+    await this.db.put(newModelVersion, {'vars': newVarsJson});
+    await this.db.put('currentModelVersion', newModelVersion);
+    this.modelVersion = newModelVersion;
   }
 }

--- a/src/server/model_db.ts
+++ b/src/server/model_db.ts
@@ -52,8 +52,8 @@ export class ModelDB {
     try {
       this.modelId = await this.db.get('currentModelId');
     } catch {
-      const dict = await model.setup();
-      await this.writeNewVars(dict.vars as tf.Tensor[]);
+      await model.setup();
+      await this.writeNewVars(model.getVars() as tf.Tensor[]);
     }
   }
 

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -15,8 +15,8 @@
  * =============================================================================
  */
 import * as tf from '@tensorflow/tfjs';
-// tslint:disable-next-line:max-line-length
-import {scalar, tensor, Tensor, test_util, variable} from '@tensorflow/tfjs-core';
+import {ModelFitConfig} from '@tensorflow/tfjs';
+import {tensor, Tensor, test_util, variable} from '@tensorflow/tfjs-core';
 import EncodingDown from 'encoding-down';
 import * as fs from 'fs';
 import LevelDown from 'leveldown';
@@ -24,7 +24,7 @@ import LevelUp from 'levelup';
 import * as rimraf from 'rimraf';
 
 import {tensorToJson} from '../serialization';
-import {FederatedModel} from '../types';
+import {FederatedModel, VarList} from '../types';
 
 import {ModelDB} from './model_db';
 
@@ -33,14 +33,13 @@ const updateId1 = '4c382c89-30cc-4f81-9197-c26e345cfb5b';
 const updateId2 = 'cdd749c0-8908-48d7-ba87-4844c831945c';
 
 class MockModel implements FederatedModel {
-  async setup() {
+  async setup() {}
+  async fit(x: Tensor, y: Tensor, fitConfig: ModelFitConfig) {}
+  setVars(vars: Tensor[]) {}
+  getVars(): VarList {
     const var1 = variable(tensor([0, 0, 0, 0], [2, 2]));
     const var2 = variable(tensor([-1, -1, -1, -1], [1, 4]));
-    return {
-      loss: (i: Tensor, l: Tensor) => scalar(1.0),
-      vars: [var1, var2],
-      predict: (_: Tensor) => _
-    };
+    return [var1, var2];
   }
 }
 

--- a/src/server/model_db_test.ts
+++ b/src/server/model_db_test.ts
@@ -15,7 +15,6 @@
  * =============================================================================
  */
 import * as tf from '@tensorflow/tfjs';
-import {ModelFitConfig} from '@tensorflow/tfjs';
 import {tensor, Tensor, test_util, variable} from '@tensorflow/tfjs-core';
 import EncodingDown from 'encoding-down';
 import * as fs from 'fs';
@@ -34,7 +33,7 @@ const updateId2 = 'cdd749c0-8908-48d7-ba87-4844c831945c';
 
 class MockModel implements FederatedModel {
   async setup() {}
-  async fit(x: Tensor, y: Tensor, fitConfig: ModelFitConfig) {}
+  async fit(x: Tensor, y: Tensor) {}
   setVars(vars: Tensor[]) {}
   getVars(): VarList {
     const var1 = variable(tensor([0, 0, 0, 0], [2, 2]));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -30,7 +30,7 @@ import * as uuid from 'uuid/v4';
 
 import {FederatedModel} from '../types';
 
-import {SocketAPI} from './comm';
+import {ServerAPI} from './comm';
 import {ModelDB} from './model_db';
 
 const mkdir = promisify(fs.mkdir);
@@ -42,7 +42,7 @@ export async function setup(model: FederatedModel, dataDir: string) {
   const io = socketIO(server);
   const modelDB = new ModelDB(dataDir);
   const FIT_CONFIG = {batchSize: 10};
-  const socketAPI = new SocketAPI(modelDB, FIT_CONFIG, io);
+  const api = new ServerAPI(modelDB, FIT_CONFIG, io);
 
   app.use(fileUpload());
 
@@ -68,7 +68,7 @@ export async function setup(model: FederatedModel, dataDir: string) {
   });
 
   return modelDB.setup(model).then(() => {
-    socketAPI.setup().then(() => {
+    api.setup().then(() => {
       server.listen(3000, () => {
         console.log('listening on 3000');
       });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -41,8 +41,7 @@ export async function setup(model: FederatedModel, dataDir: string) {
   const server = http.createServer(app);
   const io = socketIO(server);
   const modelDB = new ModelDB(dataDir);
-  const FIT_CONFIG = {batchSize: 10};
-  const api = new ServerAPI(modelDB, FIT_CONFIG, io);
+  const api = new ServerAPI(modelDB, io);
 
   app.use(fileUpload());
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,26 +16,64 @@
  */
 
 import * as tf from '@tensorflow/tfjs';
-import {Model, Tensor, Variable} from '@tensorflow/tfjs';
+import {Model, ModelFitConfig, Tensor, Variable} from '@tensorflow/tfjs';
 import {LayerVariable} from '@tensorflow/tfjs-layers/dist/variables';
 
 export type VarList = Array<Variable|LayerVariable>;
 
+/**
+ * Basic interface that users need to implement to perform federated learning.
+ *
+ * Any model that implements `fit`, `getVars` and `setVars` can be passed into
+ * a `ClientAPI` and `ServerAPI` to do federated learning.
+ */
 export interface FederatedModel {
+  /**
+   * Trains the model to better predict the given targets.
+   *
+   * @param x `tf.Tensor` of training input data.
+   * @param y `tf.Tensor` of training target data.
+   *
+   * @return A `Promise` resolved when training is done.
+   */
   fit(x: Tensor, y: Tensor): Promise<void>;
+
+  /**
+   * Gets the model's variables.
+   *
+   * @return A list of `tf.Variable`s or LayerVariables representing the model's
+   * trainable weights.
+   */
   getVars(): VarList;
+
+  /**
+   * Sets the model's variables to given values.
+   *
+   * @param vals An array of `tf.Tensor`s representing updated model weights
+   */
   setVars(vals: Tensor[]): void;
 }
 
+/**
+ * Implementation of `FederatedModel` designed to wrap a `tf.Model`.
+ */
 export class FederatedTfModel implements FederatedModel {
   private model: Model;
+  private config: ModelFitConfig;
 
-  constructor(model: Model) {
+  /**
+   * Construct a new `FederatedModel` wrapping a `tf.Model`.
+   *
+   * @param model An instance of `tf.Model` that has already been `compile`d.
+   * @param config Optional `tf.ModelFitConfig` for training.
+   */
+  constructor(model: Model, config?: ModelFitConfig) {
     this.model = model;
+    this.config = config || {epochs: 10, batchSize: 32};
   }
 
   async fit(x: Tensor, y: Tensor): Promise<void> {
-    await this.model.fit(x, y);
+    await this.model.fit(x, y, this.config);
   }
 
   getVars(): VarList {


### PR DESCRIPTION
This is a WIP pull request is relative to the `audio` branch, which will definitely break the MNIST and CIFAR experiments. I'm making this PR separate from the audio changes / larger reorganization to solicit feedback on the API changes alone.

The main changes are:
- the client API now handles fitting the model, and details like `numExamples` no longer need to be managed by users
- `FederatedModel` now has a simpler interface and can more transparently wrap `tf.Model`

Just as I'm making this, I can think of a few opportunities to simplify the interface even further, but I'll elaborate in comments on the diff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/federated-learning/15)
<!-- Reviewable:end -->
