### PR TITLE
More polishing + make federated server aware of client IDs

### DIFF
--- a/demo/audio/client/index.js
+++ b/demo/audio/client/index.js
@@ -36,7 +36,7 @@ const client = new federated.Client(serverURL, loadAudioTransferLearningModel, {
   sendMetrics: true
 });
 
-client.on('new-version', () => {
+client.onNewVersion(() => {
   ui.setVersion(client.numVersions());
 });
 
@@ -101,7 +101,7 @@ client.setup().then(async () => {
     // Compute input and label tensors
     const freqData = listener.getFrequencyData();
     const x = getInputTensorFromFrequencyData(freqData, numFrames, fftLength);
-    const y = tf.tensor2d([onehot(yTrue)]);
+    const y = tf.oneHot([yTrue], labelNames.length);
     xNpy = await npy.serialize(x);
 
     // Compute predictions
@@ -147,10 +147,4 @@ function getInputTensorFromFrequencyData(freqData, numFrames, fftLength) {
     return normalize(tensorBuffer.toTensor().reshape(
         [1, numFrames, fftLength, 1]));
   });
-}
-
-function onehot(y) {
-  const arr = new Array(labelNames.length).fill(0);
-  arr[y] = 1;
-  return arr;
 }

--- a/demo/audio/client/ui.js
+++ b/demo/audio/client/ui.js
@@ -146,7 +146,8 @@ export function createAudioElement(wavBlob) {
   resultRow.children[0].appendChild(audioControls);
 }
 
-export function castSpell(spell) {
+export function castSpell(y) {
+  const spell = labelNames[y];
   if (spell === 'nox') {
     htmlEl.classList.add('nox');
   } else if (spell === 'lumos') {

--- a/demo/audio/server/server.js
+++ b/demo/audio/server/server.js
@@ -152,7 +152,7 @@ async function setup() {
   const validLabels = tf.oneHot(validLabelsFlat, 4);
   tf.dispose(validLabelsFlat);
 
-  fedServer.on('new-version', (oldVersion, newVersion) => {
+  fedServer.onNewVersion((oldVersion, newVersion) => {
     // Save old metrics to disk, now that we're done with them
     if (metrics[oldVersion]) {
       writeFile(metricsPath(oldVersion), JSON.stringify(metrics[oldVersion]));
@@ -167,7 +167,7 @@ async function setup() {
     console.log(`Version ${newVersion} validation metrics: ${newValMetrics}`);
   });
 
-  fedServer.on('upload', msg => {
+  fedServer.onUpload(msg => {
     const version = msg.model.version;
     const clientId = msg.clientId;
     if (!metrics[version]['clients'][clientId]) {

--- a/demo/emoji_hunt/client/index.js
+++ b/demo/emoji_hunt/client/index.js
@@ -139,8 +139,8 @@ async function main() {
 
   ui.modelVersion(`model version: ${client.modelVersion()}`);
 
-  client.onNewVersion((model, oldVersion, newVersion) => {
-    console.log(model, oldVersion, newVersion, client.modelVersion());
+  client.onNewVersion((oldVersion, newVersion) => {
+    console.log(oldVersion, newVersion, client.modelVersion());
     ui.modelVersion(`model version: ${newVersion}`);
   });
 

--- a/demo/emoji_hunt/client/yarn.lock
+++ b/demo/emoji_hunt/client/yarn.lock
@@ -94,6 +94,10 @@
   version "3.0.32"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
 
+"@types/node@*":
+  version "10.5.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.8.tgz#6f14ccecad1d19332f063a6a764f8907801fece0"
+
 "@types/node@^8.9.4":
   version "8.10.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.21.tgz#12b3f2359b27aa05a45d886c8ba1eb8d1a77e285"
@@ -101,6 +105,12 @@
 "@types/socket.io-client@^1.4.32":
   version "1.4.32"
   resolved "https://registry.yarnpkg.com/@types/socket.io-client/-/socket.io-client-1.4.32.tgz#988a65a0386c274b1c22a55377fab6a30789ac14"
+
+"@types/uuid@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.3.tgz#121ace265f5569ce40f4f6d0ff78a338c732a754"
+  dependencies:
+    "@types/node" "*"
 
 abbrev@1:
   version "1.1.1"
@@ -4661,6 +4671,10 @@ util@^0.10.3:
   resolved "https://registry.yarnpkg.com/util/-/util-0.10.4.tgz#3aa0125bfe668a4672de58857d3ace27ecb76901"
   dependencies:
     inherits "2.0.3"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 v8-compile-cache@^2.0.0:
   version "2.0.0"

--- a/demo/emoji_hunt/server/index.ts
+++ b/demo/emoji_hunt/server/index.ts
@@ -57,11 +57,13 @@ app.use(cookieParser());
 
 console.log(process.env.USE_OAUTH);
 
-if (process.env.USE_OAUTH && (process.env.USE_OAUTH as any) != false) {
+// tslint:disable-next-line:no-any
+if (process.env.USE_OAUTH && (process.env.USE_OAUTH as any) !== false) {
   app.use(async (req, res, next) => {
     try {
       const token = req.cookies['oauth2token'];
       const userid = await verify(token);
+      // tslint:disable-next-line:no-any
       (req as any).googleUserID = userid;
       next();
     } catch (exn) {
@@ -85,10 +87,9 @@ app.post('/data', (req, res) => {
   }
 
   const file = req.files.file as fileUpload.UploadedFile;
-  return file.mv(
-      `${fileDir}/${file.name}`,
-      err => {err ? res.status(500).send(err.toString()) :
-                    res.send('Uploaded!')});
+  return file.mv(`${fileDir}/${file.name}`, err => {
+    err ? res.status(500).send(err.toString()) : res.send('Uploaded!');
+  });
 });
 
 setupModel(modelDir)
@@ -96,7 +97,7 @@ setupModel(modelDir)
       const federatedServer = new federated.Server(httpServer, model, {
         clientHyperparams:
             {learningRate: 3e-4, batchSize: 1, examplesPerUpdate: 1},
-        updatesPerVersion: 5,
+        serverHyperparams: {minUpdatesPerVersion: 5},
         modelDir
       });
       return federatedServer.setup().then(() => {

--- a/demo/emoji_hunt/server/model.ts
+++ b/demo/emoji_hunt/server/model.ts
@@ -56,7 +56,7 @@ export async function setupModel(saveDir: string):
   }
 
   const optimizer = tf.train.sgd(LEARNING_RATE);
-  const predict = (x: tf.Temsor) => model.predict(x);
+  const predict = (x: tf.Tensor) => model.predict(x) as tf.Tensor;
   // TODO: better to not run softmax and use softmaxCrossEntropy?
   const loss = (input: tf.Tensor, label: tf.Tensor) => {
     const preds = predict(input) as tf.Tensor;

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -14,10 +14,6 @@ const SERVER_URL = 'https://federated.learning.server';
 const INIT_MODEL = 'https://initial.com/tf-model.json';
 const client = new federated.Client(SERVER_URL, INIT_MODEL);
 
-client.onNewVersion((model, oldVersion, newVersion) => {
-  console.log(`updated model from ${oldVersion} to ${newVersion}`);
-});
-
 client.setup().then(() => {
   const yhat = client.predict(x); // make predictions!
   client.federatedUpdate(x, y); // train (and asynchronously update the server)!
@@ -105,6 +101,20 @@ This dictionary will be passed to [`tf.Model.compile`](https://js.tensorflow.org
 However, we will always set the `optimizer` to [`tf.SGDOptimizer`](https://js.tensorflow.org/api/latest/#train.sgd) to properly adopt a learning rate based on hyperparameters sent by the server. If you need more flexibility than this, you can define
 a custom [`FederatedClientModel`](./models.ts).
 
+### Client IDs
+
+By default, each federated learning client is assigned a random, anonymous identifier which is persisted in cookie storage. This ID is sent to the server alongside weight updates to enable features that prevent individual clients from dominating the aggregation process. It can also be helpful for anonymized performance metric analysis, e.g. determining if the gains of federated learning are going to one group of users at the expense of a minority.
+
+If you would like to assign your own custom client identifier not stored in a cookie, you can do so as follows:
+
+```js
+new federated.Client(SERVER_URL, MODEL_URL, {
+  clientId: 'custom-id'
+});
+```
+
+In the future, we hope to support client identifiers tied to rate-limited authentication strategies to help prevent bot users from flooding the server with spurious updates.
+
 ### Getting Stats
 
 For printing and debugging purposes, you can get stats about the client using:
@@ -121,13 +131,29 @@ client.numExamplesPerUpdate() // how many examples used in each update
 client.numExamplesRemaining() // how many more examples needed before updating
 ```
 
-You can also listen for changes in the model version by doing:
+You can also listen for changes in the model version (or successful uploads) by doing:
 ```js
-client.onNewVersion((model, oldVersion, newVersion) => {
+client.on('new-version', (oldVersion, newVersion) => {
   console.log(`you've seen ${client.numVersions()} versions now!`);
   $('#model-version').text(`Model Version #${newVersion}`);
 });
+
+client.on('upload', uploadMessage => {
+  console.log(`uploaded another version to the server!`);
+});
 ```
+
+### Sending Metrics
+
+By default, federated clients will only send updated weights to the server. However, you can configure them to also send the results of `client.evaluate(x, y)` by setting the `sendMetrics` config flag to `true`:
+
+```js
+new federated.Client(SERVER_URL, MODEL_URL, {
+  sendMetrics: true
+})
+```
+
+If `evaluate` returns the exact training loss, then sending this information could make the federated learning process slightly less private, but it is helpful for server-side performance monitoring.
 
 ### TODO
 

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -133,12 +133,12 @@ client.numExamplesRemaining() // how many more examples needed before updating
 
 You can also listen for changes in the model version (or successful uploads) by doing:
 ```js
-client.on('new-version', (oldVersion, newVersion) => {
+client.onNewVersion((oldVersion, newVersion) => {
   console.log(`you've seen ${client.numVersions()} versions now!`);
   $('#model-version').text(`Model Version #${newVersion}`);
 });
 
-client.on('upload', uploadMessage => {
+client.onUpload(uploadMessage => {
   console.log(`uploaded another version to the server!`);
 });
 ```

--- a/src/client/README.md
+++ b/src/client/README.md
@@ -48,7 +48,7 @@ new federated.Client(SERVER_URL, federatedClientModel); // if you need custom be
 
 You can pass a `FederatedClientModel` if you need custom behavior not supported by `tf.Model`s. See its [documentation](./models.ts) for the methods you will need to implement.
 
-Currently, we do not support loading the model automatically from the server (e.g. just doing `federated.Client(SERVER_URL)`). If the model you want to load client-side is only hosted on your federated learning server, but is a `tf.Model`, you can implement this fairly simply by statically serving the model files. Here is an example of how to do this with `express`:
+Currently, we do not support loading the model automatically from the server (e.g. just doing `federated.Client(SERVER_URL)`). If the model you want to load client-side is only hosted on your federated learning server, but is a `tf.Model`, you can implement this fairly simply by statically serving the model files, which are conveniently symlinked. Here is an example of how to do this with `express`:
 
 ```js
 // server
@@ -57,14 +57,14 @@ const dir = '/models';
 app.use(express.static(dir));
 const webServer = http.createServer(app);
 const fedServer = new federated.Server(webServer, initModel, {
-   modelDir: dir // newest model will be symlinked to ${dir}/latest
+   modelDir: dir // current model will be symlinked to ${dir}/current
 });
 await fedServer.setup();
 webServer.listen(80);
 
 // client
 const url = 'http://my.server';
-const fedClient = new federated.Client(url, `${url}/latest/model.json`);
+const fedClient = new federated.Client(url, `${url}/current/model.json`);
 await fedClient.setup();
 ```
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -111,19 +111,23 @@ export class Client {
   }
 
   /**
-   * Register a new callback to be invoked whenever the specified event occurs
+   * Register a new callback to be invoked whenever the server updates the model
+   * version.
    *
-   * @param event must be "new-version"
-   * @param callback function to be called on each event
+   * @param callback function to be called (w/ old and new version IDs)
    */
-  on(event: string, callback: VersionCallback|UploadCallback) {
-    if (event === 'new-version') {
-      this.versionCallbacks.push(callback as VersionCallback);
-    } else if (event === 'upload') {
-      this.uploadCallbacks.push(callback as UploadCallback);
-    } else {
-      throw new Error(`unrecognized event ${event}`);
-    }
+  onNewVersion(callback: VersionCallback) {
+    this.versionCallbacks.push(callback);
+  }
+
+  /**
+   * Register a new callback to be invoked whenever the client uploads a new set
+   * of weights.
+   *
+   * @param callback function to be called (w/ client's upload msg)
+   */
+  onUpload(callback: UploadCallback) {
+    this.uploadCallbacks.push(callback);
   }
 
   /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -18,8 +18,9 @@
 import * as tf from '@tensorflow/tfjs';
 import * as socketProxy from 'socket.io-client';
 import * as uuid from 'uuid/v4';
+
 // tslint:disable-next-line:max-line-length
-import {FederatedCompileConfig, VersionCallback, DownloadMsg, Events, deserializeVar, SerializedVariable, serializeVars, AsyncTfModel, UploadMsg, UploadCallback} from './common';
+import {AsyncTfModel, deserializeVar, DownloadMsg, Events, FederatedCompileConfig, SerializedVariable, serializeVars, UploadCallback, UploadMsg, VersionCallback} from './common';
 // tslint:disable-next-line:max-line-length
 import {FederatedClientModel, FederatedClientTfModel, isFederatedClientModel} from './models';
 
@@ -76,8 +77,8 @@ export class Client {
    * @param model - model to use with federated learning
    */
   constructor(
-    serverUrl: string, model: FederatedClientModel | AsyncTfModel,
-    config?: FederatedClientConfig) {
+      serverUrl: string, model: FederatedClientModel|AsyncTfModel,
+      config?: FederatedClientConfig) {
     this.serverUrl = serverUrl;
     if (isFederatedClientModel(model)) {
       this.model = model;
@@ -115,7 +116,7 @@ export class Client {
    * @param event must be "new-version"
    * @param callback function to be called on each event
    */
-  on(event: string, callback: VersionCallback | UploadCallback) {
+  on(event: string, callback: VersionCallback|UploadCallback) {
     if (event === 'new-version') {
       this.versionCallbacks.push(callback as VersionCallback);
     } else if (event === 'upload') {
@@ -151,8 +152,7 @@ export class Client {
       this.msg = msg;
       this.setVars(msg.model.vars);
       this.versionUpdateCounts[newVersion] = 0;
-      this.versionCallbacks.forEach(
-        cb => cb(oldVersion, newVersion));
+      this.versionCallbacks.forEach(cb => cb(oldVersion, newVersion));
     });
   }
 
@@ -235,10 +235,7 @@ export class Client {
 
       // upload the updates to the server
       const uploadMsg: UploadMsg = {
-        model: {
-          version: modelVersion,
-          vars: newVars
-        },
+        model: {version: modelVersion, vars: newVars},
         clientId: this.clientId,
       };
       if (this.sendMetrics) {
@@ -309,7 +306,7 @@ export class Client {
   private async uploadVars(msg: UploadMsg): Promise<{}> {
     const prom = new Promise((resolve, reject) => {
       const rejectTimer =
-        setTimeout(() => reject(`uploadVars timed out`), UPLOAD_TIMEOUT);
+          setTimeout(() => reject(`uploadVars timed out`), UPLOAD_TIMEOUT);
       this.socket.emit(Events.Upload, msg, () => {
         clearTimeout(rejectTimer);
         resolve();
@@ -327,7 +324,7 @@ export class Client {
   private async connectTo(serverURL: string): Promise<DownloadMsg> {
     this.socket = socketio(serverURL);
     return fromEvent<DownloadMsg>(
-      this.socket, Events.Download, CONNECTION_TIMEOUT);
+        this.socket, Events.Download, CONNECTION_TIMEOUT);
   }
 
   // tslint:disable-next-line:no-any
@@ -346,19 +343,19 @@ export class Client {
 }
 
 async function fromEvent<T>(
-  emitter: SocketIOClient.Socket, eventName: string,
-  timeout: number): Promise<T> {
+    emitter: SocketIOClient.Socket, eventName: string,
+    timeout: number): Promise<T> {
   return new Promise((resolve, reject) => {
-    const rejectTimer = setTimeout(
-      () => reject(`${eventName} event timed out`), timeout);
-    const listener = (evtArgs: T) => {
-      emitter.removeListener(eventName, listener);
-      clearTimeout(rejectTimer);
+           const rejectTimer = setTimeout(
+               () => reject(`${eventName} event timed out`), timeout);
+           const listener = (evtArgs: T) => {
+             emitter.removeListener(eventName, listener);
+             clearTimeout(rejectTimer);
 
-      resolve(evtArgs);
-    };
-    emitter.on(eventName, listener);
-  }) as Promise<T>;
+             resolve(evtArgs);
+           };
+           emitter.on(eventName, listener);
+         }) as Promise<T>;
 }
 
 // TODO: remove once tfjs >= 0.12.5 is released
@@ -383,7 +380,7 @@ function sliceWithEmptyTensors(a: tf.Tensor, begin: number, size?: number) {
 function addRows(existing: tf.Tensor, newEls: tf.Tensor, unitShape: number[]) {
   if (tf.util.arraysEqual(newEls.shape, unitShape)) {
     return tf.tidy(
-      () => concatWithEmptyTensors(existing, tf.expandDims(newEls)));
+        () => concatWithEmptyTensors(existing, tf.expandDims(newEls)));
   } else {  // batch dimension
     tf.util.assertShapesMatch(newEls.shape.slice(1), unitShape);
     return tf.tidy(() => concatWithEmptyTensors(existing, newEls));
@@ -404,5 +401,5 @@ function setCookie(name: string, value: string) {
   }
   const d = new Date();
   d.setTime(d.getTime() + YEAR_IN_MS);
-  document.cookie = name + "=" + value + ";path=/;expires=" + d.toUTCString();
+  document.cookie = name + '=' + value + ';path=/;expires=' + d.toUTCString();
 }

--- a/src/client/models.ts
+++ b/src/client/models.ts
@@ -32,8 +32,8 @@ export interface FederatedClientModel extends FederatedModel {
  * function returning a `tf.Model`, or a string that can be passed to
  * `tf.loadModel`.
  */
-export class FederatedClientTfModel extends FederatedTfModel
-  implements FederatedClientModel {
+export class FederatedClientTfModel extends FederatedTfModel implements
+    FederatedClientModel {
   isFederatedClientModel = true;
 
   async setup() {
@@ -46,7 +46,8 @@ export class FederatedClientTfModel extends FederatedTfModel
  *
  * @param model any object
  */
+// tslint:disable-next-line:no-any
 export function isFederatedClientModel(model: any):
-  model is FederatedClientModel {
+    model is FederatedClientModel {
   return model && model.isFederatedClientModel;
 }

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -19,7 +19,9 @@
   "dependencies": {
     "@tensorflow/tfjs": "~0.12",
     "@types/socket.io-client": "^1.4.32",
-    "socket.io-client": "^2.1.1"
+    "@types/uuid": "^3.4.3",
+    "socket.io-client": "^2.1.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "clang-format": "~1.2.2",

--- a/src/client/yarn.lock
+++ b/src/client/yarn.lock
@@ -82,7 +82,7 @@
   version "3.0.32"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
 
-"@types/node@^10.1.0":
+"@types/node@*", "@types/node@^10.1.0":
   version "10.5.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.7.tgz#960d9feb3ade2233bcc9843c918d740b4f78a7cf"
 
@@ -93,6 +93,12 @@
 "@types/socket.io-client@^1.4.32":
   version "1.4.32"
   resolved "https://registry.yarnpkg.com/@types/socket.io-client/-/socket.io-client-1.4.32.tgz#988a65a0386c274b1c22a55377fab6a30789ac14"
+
+"@types/uuid@^3.4.3":
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.3.tgz#121ace265f5569ce40f4f6d0ff78a338c732a754"
+  dependencies:
+    "@types/node" "*"
 
 "@types/webgl-ext@~0.0.29":
   version "0.0.29"
@@ -969,6 +975,10 @@ user-home@^2.0.0:
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
   dependencies:
     os-homedir "^1.0.0"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -162,10 +162,10 @@ export type ClientHyperparams = {
 export type ServerHyperparams = {
   aggregation?: string,
   minUpdatesPerVersion?: number,
-  //minClientsPerVersion?: number,
-  //maxUpdatesPerClient?: number,
-  //maxUpdateL2Norm?: number
-}
+  // minClientsPerVersion?: number,
+  // maxUpdatesPerClient?: number,
+  // maxUpdateL2Norm?: number
+};
 
 export const DEFAULT_CLIENT_HYPERPARAMS: ClientHyperparams = {
   examplesPerUpdate: 5,
@@ -178,17 +178,19 @@ export const DEFAULT_CLIENT_HYPERPARAMS: ClientHyperparams = {
 export const DEFAULT_SERVER_HYPERPARAMS: ServerHyperparams = {
   aggregation: 'mean',
   minUpdatesPerVersion: 20,
-  //minClientsPerVersion: 1,
-  //maxUpdatesPerClient: 20,
-  //maxUpdateL2Norm: 0
+  // minClientsPerVersion: 1,
+  // maxUpdatesPerClient: 20,
+  // maxUpdateL2Norm: 0
 };
 
+// tslint:disable-next-line:no-any
 function override(defaults: any, choices: any) {
+  // tslint:disable-next-line:no-any
   const result: any = {};
-  for (let key in defaults) {
+  for (const key in defaults) {
     result[key] = (choices || {})[key] || defaults[key];
   }
-  for (let key in (choices || {})) {
+  for (const key in (choices || {})) {
     if (!(key in defaults)) {
       throw new Error(`Unrecognized key "${key}"`);
     }

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -161,10 +161,7 @@ export type ClientHyperparams = {
 
 export type ServerHyperparams = {
   aggregation?: string,
-  minUpdatesPerVersion?: number,
-  // minClientsPerVersion?: number,
-  // maxUpdatesPerClient?: number,
-  // maxUpdateL2Norm?: number
+  minUpdatesPerVersion?: number
 };
 
 export const DEFAULT_CLIENT_HYPERPARAMS: ClientHyperparams = {
@@ -177,10 +174,7 @@ export const DEFAULT_CLIENT_HYPERPARAMS: ClientHyperparams = {
 
 export const DEFAULT_SERVER_HYPERPARAMS: ServerHyperparams = {
   aggregation: 'mean',
-  minUpdatesPerVersion: 20,
-  // minClientsPerVersion: 1,
-  // maxUpdatesPerClient: 20,
-  // maxUpdateL2Norm: 0
+  minUpdatesPerVersion: 20
 };
 
 // tslint:disable-next-line:no-any

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -71,7 +71,7 @@ Many of these hyperparameters matter a great deal for the efficiency and privacy
 You can add an event listener that fires each time a client uploads a new set of weights (and optionally, self-reported metrics of how well the model performed on the examples used in training):
 
 ```js
-fedServer.on('upload', message => {
+fedServer.onUpload(message => {
   console.log(message.model.version); // version of the model
   console.log(message.model.vars); // serialized model variables
   console.log(message.clientId); // self-reported and usually random client ID
@@ -82,7 +82,7 @@ fedServer.on('upload', message => {
 You can also listen for whenever the server computes a new version of the model:
 
 ```js
-fedServer.on('new-version', (oldVersion, newVersion) => {
+fedServer.onNewVersion((oldVersion, newVersion) => {
   console.log(`updated model from ${oldVersion} to ${newVersion}`);
 });
 ```

--- a/src/server/models.ts
+++ b/src/server/models.ts
@@ -214,9 +214,8 @@ export class FederatedServerDynamicModel extends FederatedDynamicModel
     const path = `${this.saveDir}/${version}/`;
     const jsonPath = `${path}/meta.json`;
     const binPath = `${path}/data.bin`;
-    const json =
-        JSON.parse(await readFile(jsonPath, {flag: 'r', encoding: 'utf8'}));
-    const data = await readFile(binPath, {flag: 'rb'});
+    const json = JSON.parse(await readFile(jsonPath, {encoding: 'utf8'}));
+    const data = await readFile(binPath);
     return flatDeserialize({data, json});
   }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -147,20 +147,23 @@ export class Server {
   }
 
   /**
-   * Register a new callback to be invoked whenever the server triggers the
-   * specified event
+   * Register a new callback to be invoked whenever the server updates the model
+   * version.
    *
-   * @param event must be "new-version" or "upload"
-   * @param callback function to be called on each event
+   * @param callback function to be called (w/ old and new version IDs)
    */
-  on(event: string, callback: VersionCallback|UploadCallback) {
-    if (event === 'new-version') {
-      this.versionCallbacks.push(callback as VersionCallback);
-    } else if (event === 'upload') {
-      this.uploadCallbacks.push(callback as UploadCallback);
-    } else {
-      throw new Error(`unrecognized event ${event}`);
-    }
+  onNewVersion(callback: VersionCallback) {
+    this.versionCallbacks.push(callback);
+  }
+
+  /**
+   * Register a new callback to be invoked whenever the client uploads a new set
+   * of weights.
+   *
+   * @param callback function to be called (w/ client's upload msg)
+   */
+  onUpload(callback: UploadCallback) {
+    this.uploadCallbacks.push(callback);
   }
 
   private async computeDownloadMsg(): Promise<DownloadMsg> {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -22,7 +22,7 @@ import * as path from 'path';
 import * as io from 'socket.io';
 
 // tslint:disable-next-line:max-line-length
-import {FederatedCompileConfig, deserializeVars, DownloadMsg, Events, SerializedVariable, serializeVars, stackSerialized, clientHyperparams, ClientHyperparams, VersionCallback, UploadMsg, AsyncTfModel, UploadCallback, serverHyperparams, ServerHyperparams} from './common';
+import {AsyncTfModel, clientHyperparams, ClientHyperparams, deserializeVars, DownloadMsg, Events, FederatedCompileConfig, SerializedVariable, serializeVars, serverHyperparams, ServerHyperparams, stackSerialized, UploadCallback, UploadMsg, VersionCallback} from './common';
 // tslint:disable-next-line:max-line-length
 import {FederatedServerModel, FederatedServerTfModel, isFederatedServerModel} from './models';
 
@@ -89,7 +89,7 @@ export class Server {
     this.serverHyperparams = serverHyperparams(config.serverHyperparams || {});
     this.downloadMsg = null;
     this.uploadCallbacks = [];
-    this.versionCallbacks = [(model, v1, v2) => {
+    this.versionCallbacks = [(v1, v2) => {
       this.log(`updated model: ${v1} -> ${v2}`);
     }];
   }
@@ -143,9 +143,7 @@ export class Server {
 
   private shouldUpdate(): boolean {
     const numUpdates = this.numUpdates;
-    return (
-      numUpdates >= this.serverHyperparams.minUpdatesPerVersion
-    );
+    return (numUpdates >= this.serverHyperparams.minUpdatesPerVersion);
   }
 
   /**
@@ -155,7 +153,7 @@ export class Server {
    * @param event must be "new-version" or "upload"
    * @param callback function to be called on each event
    */
-  on(event: string, callback: VersionCallback | UploadCallback) {
+  on(event: string, callback: VersionCallback|UploadCallback) {
     if (event === 'new-version') {
       this.versionCallbacks.push(callback as VersionCallback);
     } else if (event === 'upload') {

--- a/test/api_test.ts
+++ b/test/api_test.ts
@@ -94,7 +94,7 @@ describe('Server-to-client API', () => {
   });
 
   it('triggers a download after enough uploads', async (done) => {
-    client.on('new-version', (oldVersion, newVersion) => {
+    client.onNewVersion((oldVersion, newVersion) => {
       expect(oldVersion).toBe(initVersion);
       expect(newVersion).not.toBe(initVersion);
       expect(newVersion).toBe(server.model.version);

--- a/test/api_test.ts
+++ b/test/api_test.ts
@@ -18,17 +18,18 @@
 
 import * as tf from '@tensorflow/tfjs';
 import {test_util} from '@tensorflow/tfjs';
-import {MockModel} from './mock_model';
 import {Client} from 'federated-learning-client';
 import {Server} from 'federated-learning-server';
 import * as fs from 'fs';
 import * as http from 'http';
 import * as rimraf from 'rimraf';
 
+import {MockModel} from './mock_model';
+
 const PORT = 3001;
 const socketURL = `http://0.0.0.0:${PORT}`;
 const initWeights =
-  [tf.tensor([1, 1, 1, 1], [2, 2]), tf.tensor([1, 2, 3, 4], [1, 4])];
+    [tf.tensor([1, 1, 1, 1], [2, 2]), tf.tensor([1, 2, 3, 4], [1, 4])];
 const initVersion = 'initial';
 
 describe('Server-to-client API', () => {
@@ -58,9 +59,7 @@ describe('Server-to-client API', () => {
       serverHyperparams: {
         minUpdatesPerVersion: 2,
       },
-      clientHyperparams: {
-        examplesPerUpdate: 1
-      }
+      clientHyperparams: {examplesPerUpdate: 1}
     });
     await server.setup();
 
@@ -100,13 +99,13 @@ describe('Server-to-client API', () => {
       expect(newVersion).not.toBe(initVersion);
       expect(newVersion).toBe(server.model.version);
       test_util.expectArraysClose(
-        clientVars[0], tf.tensor([1.5, 1.5, 1.5, 1.5], [2, 2]));
+          clientVars[0], tf.tensor([1.5, 1.5, 1.5, 1.5], [2, 2]));
       test_util.expectArraysClose(
-        clientVars[1], tf.tensor([3.0, 3.0, 3.0, 2.5], [1, 4]));
+          clientVars[1], tf.tensor([3.0, 3.0, 3.0, 2.5], [1, 4]));
       done();
     });
 
-    const dummyX1 = tf.tensor2d([[0]]);            // 1 example
+    const dummyX1 = tf.tensor2d([[0]]);  // 1 example
     const dummyY1 = tf.tensor2d([[0]]);
     const dummyX3 = tf.tensor2d([[0], [0], [0]]);  // 3 examples
     const dummyY3 = tf.tensor2d([[0], [0], [0]]);

--- a/test/mock_model.ts
+++ b/test/mock_model.ts
@@ -17,7 +17,8 @@
 
 import {Tensor, Variable} from '@tensorflow/tfjs';
 import {FederatedClientModel} from 'federated-learning-client';
-import {FederatedServerModel, FederatedFitConfig} from 'federated-learning-server';
+// tslint:disable-next-line:max-line-length
+import {FederatedFitConfig, FederatedServerModel} from 'federated-learning-server';
 
 export class MockModel implements FederatedServerModel, FederatedClientModel {
   isFederatedClientModel = true;

--- a/test/mock_model.ts
+++ b/test/mock_model.ts
@@ -1,0 +1,59 @@
+/**
+ * * @license
+ * Copyright 2018 Google LLC. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {Tensor, Variable} from '@tensorflow/tfjs';
+import {FederatedClientModel} from 'federated-learning-client';
+import {FederatedServerModel, FederatedFitConfig} from 'federated-learning-server';
+
+export class MockModel implements FederatedServerModel, FederatedClientModel {
+  isFederatedClientModel = true;
+  isFederatedServerModel = true;
+  inputShape = [1];
+  outputShape = [1];
+  vars: Variable[];
+  version: string;
+
+  constructor(vars: Variable[]) {
+    this.vars = vars;
+  }
+
+  async fit(x: Tensor, y: Tensor, config?: FederatedFitConfig) {}
+
+  async setup() {}
+
+  async save() {
+    this.version = new Date().getTime().toString();
+  }
+
+  setVars(vars: Tensor[]) {
+    for (let i = 0; i < this.vars.length; i++) {
+      this.vars[i].assign(vars[i]);
+    }
+  }
+
+  getVars(): Tensor[] {
+    return this.vars;
+  }
+
+  predict(x: Tensor) {
+    return x;
+  }
+
+  evaluate(x: Tensor, y: Tensor) {
+    return [0];
+  }
+}


### PR DESCRIPTION
This pull request continues to refactor and polish the codebase. It also:
- updates the federated learning client to send client IDs and optional metrics to the server.
- changes `onNewVersion(fn)` -> `on('new-version', fn)` and introduces `on('upload', fn)`, which it uses for metrics instead
- prepares the federated learning server to support custom weighting of client averages (to ensure no individual client dominates an update)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/federated-learning/36)
<!-- Reviewable:end -->
